### PR TITLE
feat(preset): add trainer preset registry

### DIFF
--- a/docs/learn/0009-preset-domain-registry/README.md
+++ b/docs/learn/0009-preset-domain-registry/README.md
@@ -1,0 +1,28 @@
+# Preset Domain Registry
+
+PR: #26
+Date: 2026-05-09
+
+## What was done
+
+- `Preset`, `TrainerPreset`, `OptionPolicy`, `OptionRule` 타입을 preset 도메인 패키지에 추가했다.
+- Phase 0 trainer preset fixture를 structured data로 표현했다.
+- ID 기반 static registry와 defensive-copy 테스트를 추가했다.
+
+## Categories
+
+- [Code Design](./code-design.md)
+- [Go Programming](./go.md)
+
+## Key decisions
+
+| Decision | Why | Alternatives considered |
+|----------|-----|-------------------------|
+| registry lookup은 ID 기반 | display name은 변경될 수 있지만 ID는 stable identity이기 때문 | display name lookup |
+| `preset.ID`는 `run.PresetID` alias | request contract와 manager domain identity를 타입으로 연결하기 위해 | 별도 string type 변환 |
+| fixtures는 YAML이 아닌 Go data | manager가 structured data를 source of truth로 다루기 위해 | embedded YAML fixture |
+
+## Further study
+
+- [ ] DB-backed `PresetRegistry`가 static registry와 같은 interface를 만족하는 구조 설계
+- [ ] trainer/resource/output preset이 같은 `Preset` interface를 공유할 때 필요한 공통 필드 점검

--- a/docs/learn/0009-preset-domain-registry/code-design.md
+++ b/docs/learn/0009-preset-domain-registry/code-design.md
@@ -1,0 +1,22 @@
+# Code Design
+
+## Preset Interface
+
+`Preset` interface는 processor와 validator가 concrete `TrainerPreset`에 직접 묶이지 않게 하는 얇은 추상화다. Phase 0에서는 trainer preset만 있지만, resource/output preset이 추가되더라도 ID, policy, defaults라는 공통 surface는 유지할 수 있다.
+
+```go
+type Preset interface {
+	PresetID() ID
+	OptionPolicy() OptionPolicy
+	Defaults() map[string]any
+}
+```
+
+이 interface는 "모든 preset이 trainer runtime을 가진다" 같은 잘못된 가정을 피한다. trainer-specific 정보는 `TrainerPreset` concrete type에 남긴다.
+
+## OptionPolicy는 Validator의 입력 데이터
+
+`OptionPolicy`와 `OptionRule`은 validation을 직접 수행하지 않는다. 어떤 key가 허용되는지, value type과 numeric range가 무엇인지를 structured data로 표현할 뿐이다.
+
+이렇게 나누면 policy fixture는 순수 데이터로 유지되고, 실제 검증 규칙은 별도 validator 구현에서 테스트할 수 있다.
+

--- a/docs/learn/0009-preset-domain-registry/go.md
+++ b/docs/learn/0009-preset-domain-registry/go.md
@@ -1,0 +1,14 @@
+# Go Programming
+
+## Type Alias와 New Type의 차이
+
+`type ID = run.PresetID`는 alias라서 두 타입이 동일하게 취급된다. 이 선택은 submitted spec의 `run.PresetID`와 manager preset package의 `preset.ID`가 같은 identity를 가리킨다는 의도를 표현한다.
+
+반대로 `type OptionValueType string`은 new type이다. string 기반 표현을 유지하면서도 함수 시그니처나 struct field에서 "아무 string"이 아니라 option value type임을 드러낼 수 있다.
+
+## Defensive Copy
+
+map과 slice는 reference-like value라서 그대로 반환하면 caller가 내부 fixture state를 바꿀 수 있다. `Defaults()`와 `OptionPolicy()`는 copy를 반환해서 registry에 등록된 preset data를 immutable처럼 다룰 수 있게 한다.
+
+테스트에서는 반환된 map/slice를 수정한 뒤 registry에서 다시 조회했을 때 원본이 유지되는지 확인한다.
+

--- a/internal/manager/preset/fixtures.go
+++ b/internal/manager/preset/fixtures.go
@@ -1,0 +1,98 @@
+package preset
+
+// Phase0Presets returns the structured trainer presets supported in Phase 0.
+func Phase0Presets() []TrainerPreset {
+	return []TrainerPreset{
+		AxolotlLoRASFT(),
+		UnslothLoRASFT(),
+	}
+}
+
+// AxolotlLoRASFT returns the Phase 0 Axolotl LoRA SFT trainer preset.
+func AxolotlLoRASFT() TrainerPreset {
+	return TrainerPreset{
+		ID:          PresetAxolotlLoRASFT,
+		DisplayName: "Axolotl LoRA SFT",
+		Runtime: RuntimeSpec{
+			Image:      "axolotl:latest",
+			Entrypoint: []string{"axolotl", "train", "/workspace/resolved_config.yaml"},
+			Env: map[string]string{
+				"HF_HOME": "/cache/huggingface",
+			},
+		},
+		DefaultValues: map[string]any{
+			"learning_rate":    2.0e-4,
+			"num_epochs":       3,
+			"max_seq_length":   4096,
+			"lora_r":           16,
+			"lora_alpha":       32,
+			"micro_batch_size": 1,
+		},
+		Policy: loraSFTOptionPolicy(),
+	}
+}
+
+// UnslothLoRASFT returns the Phase 0 Unsloth LoRA SFT trainer preset.
+func UnslothLoRASFT() TrainerPreset {
+	return TrainerPreset{
+		ID:          PresetUnslothLoRASFT,
+		DisplayName: "Unsloth LoRA SFT",
+		Runtime: RuntimeSpec{
+			Image:      "unsloth:latest",
+			Entrypoint: []string{"python", "-m", "nano_backend.train_unsloth", "--config", "/workspace/resolved_config.yaml"},
+			Env: map[string]string{
+				"HF_HOME": "/cache/huggingface",
+			},
+		},
+		DefaultValues: map[string]any{
+			"learning_rate":    2.0e-4,
+			"num_epochs":       3,
+			"max_seq_length":   4096,
+			"lora_r":           16,
+			"lora_alpha":       32,
+			"micro_batch_size": 1,
+		},
+		Policy: loraSFTOptionPolicy(),
+	}
+}
+
+func loraSFTOptionPolicy() OptionPolicy {
+	return OptionPolicy{
+		Rules: map[string]OptionRule{
+			"learning_rate": {
+				Type: OptionFloat,
+				Min:  float64Ptr(0),
+				Max:  float64Ptr(1),
+			},
+			"num_epochs": {
+				Type: OptionInt,
+				Min:  float64Ptr(1),
+				Max:  float64Ptr(100),
+			},
+			"max_seq_length": {
+				Type: OptionInt,
+				Min:  float64Ptr(128),
+				Max:  float64Ptr(32768),
+			},
+			"lora_r": {
+				Type: OptionInt,
+				Min:  float64Ptr(1),
+				Max:  float64Ptr(256),
+			},
+			"lora_alpha": {
+				Type: OptionInt,
+				Min:  float64Ptr(1),
+				Max:  float64Ptr(512),
+			},
+			"micro_batch_size": {
+				Type: OptionInt,
+				Min:  float64Ptr(1),
+				Max:  float64Ptr(64),
+			},
+		},
+	}
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}

--- a/internal/manager/preset/preset.go
+++ b/internal/manager/preset/preset.go
@@ -1,0 +1,127 @@
+package preset
+
+import "github.com/seedspirit/nano-backend.ai/internal/common/run"
+
+// ID is the stable identity for a trainer preset.
+type ID = run.PresetID
+
+const (
+	// PresetAxolotlLoRASFT identifies the Phase 0 Axolotl LoRA SFT preset.
+	PresetAxolotlLoRASFT ID = "axolotl-lora-sft"
+	// PresetUnslothLoRASFT identifies the Phase 0 Unsloth LoRA SFT preset.
+	PresetUnslothLoRASFT ID = "unsloth-lora-sft"
+)
+
+// Preset is the validation and finalization contract consumed by RunSpec code.
+type Preset interface {
+	PresetID() ID
+	OptionPolicy() OptionPolicy
+	Defaults() map[string]any
+}
+
+// TrainerPreset defines a trainer runtime and the parameter surface exposed to users.
+type TrainerPreset struct {
+	ID            ID
+	DisplayName   string
+	Runtime       RuntimeSpec
+	DefaultValues map[string]any
+	Policy        OptionPolicy
+}
+
+// RuntimeSpec describes how a preset is materialized by a runtime adapter.
+type RuntimeSpec struct {
+	Image      string
+	Entrypoint []string
+	Env        map[string]string
+}
+
+// OptionPolicy describes which parameter keys and value shapes a preset accepts.
+type OptionPolicy struct {
+	Rules map[string]OptionRule
+}
+
+// OptionRule constrains a single parameter key.
+type OptionRule struct {
+	Type OptionValueType
+	Min  *float64
+	Max  *float64
+}
+
+// OptionValueType is a typed string enum used by validators.
+type OptionValueType string
+
+const (
+	// OptionString requires a string parameter value.
+	OptionString OptionValueType = "string"
+	// OptionInt requires an integer parameter value.
+	OptionInt OptionValueType = "int"
+	// OptionFloat requires a numeric parameter value.
+	OptionFloat OptionValueType = "float"
+	// OptionBool requires a boolean parameter value.
+	OptionBool OptionValueType = "bool"
+)
+
+// PresetID returns the stable identity of the preset.
+func (p *TrainerPreset) PresetID() ID {
+	return p.ID
+}
+
+// OptionPolicy returns a copy of the preset option policy.
+func (p *TrainerPreset) OptionPolicy() OptionPolicy {
+	return OptionPolicy{Rules: cloneRules(p.Policy.Rules)}
+}
+
+// Defaults returns a copy of the preset default training values.
+func (p *TrainerPreset) Defaults() map[string]any {
+	return cloneAnyMap(p.DefaultValues)
+}
+
+func cloneRules(rules map[string]OptionRule) map[string]OptionRule {
+	if rules == nil {
+		return nil
+	}
+	cloned := make(map[string]OptionRule, len(rules))
+	for key, rule := range rules {
+		cloned[key] = cloneRule(rule)
+	}
+	return cloned
+}
+
+func cloneRule(rule OptionRule) OptionRule {
+	cloned := rule
+	if rule.Min != nil {
+		value := *rule.Min
+		cloned.Min = &value
+	}
+	if rule.Max != nil {
+		value := *rule.Max
+		cloned.Max = &value
+	}
+	return cloned
+}
+
+func cloneAnyMap(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(values))
+	for key, value := range values {
+		cloned[key] = cloneAny(value)
+	}
+	return cloned
+}
+
+func cloneAny(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneAny(item)
+		}
+		return cloned
+	default:
+		return value
+	}
+}

--- a/internal/manager/preset/registry.go
+++ b/internal/manager/preset/registry.go
@@ -1,0 +1,63 @@
+package preset
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
+)
+
+// StaticRegistry stores presets in memory.
+type StaticRegistry struct {
+	presets map[ID]*TrainerPreset
+}
+
+// NewStaticRegistry creates an in-memory registry from structured presets.
+func NewStaticRegistry(presets ...TrainerPreset) StaticRegistry {
+	registered := make(map[ID]*TrainerPreset, len(presets))
+	for _, trainerPreset := range presets {
+		presetCopy := trainerPreset
+		registered[trainerPreset.ID] = &presetCopy
+	}
+	return StaticRegistry{presets: registered}
+}
+
+// Get returns a preset by stable ID.
+func (r StaticRegistry) Get(ctx context.Context, id ID) (Preset, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	trainerPreset, ok := r.presets[id]
+	if !ok {
+		return nil, errordef.Errorf(errordef.NotFound, "preset %q not found", id)
+	}
+	return trainerPreset, nil
+}
+
+// List returns all registered presets ordered by stable ID.
+func (r StaticRegistry) List(ctx context.Context) ([]Preset, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(r.presets))
+	for id := range r.presets {
+		ids = append(ids, string(id))
+	}
+	sort.Strings(ids)
+
+	presets := make([]Preset, 0, len(ids))
+	for _, id := range ids {
+		trainerPreset, ok := r.presets[ID(id)]
+		if !ok {
+			return nil, fmt.Errorf("preset registry changed while listing")
+		}
+		presets = append(presets, trainerPreset)
+	}
+	return presets, nil
+}
+
+// NewPhase0Registry creates the default Phase 0 trainer preset registry.
+func NewPhase0Registry() StaticRegistry {
+	return NewStaticRegistry(Phase0Presets()...)
+}

--- a/internal/manager/preset/registry_test.go
+++ b/internal/manager/preset/registry_test.go
@@ -1,0 +1,75 @@
+package preset
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
+)
+
+func TestPhase0RegistryGetsPresetsByID(t *testing.T) {
+	ctx := context.Background()
+	registry := NewPhase0Registry()
+
+	axolotl, err := registry.Get(ctx, PresetAxolotlLoRASFT)
+	if err != nil {
+		t.Fatalf("get axolotl preset: %v", err)
+	}
+	if axolotl.PresetID() != PresetAxolotlLoRASFT {
+		t.Fatalf("got preset id %q, want %q", axolotl.PresetID(), PresetAxolotlLoRASFT)
+	}
+
+	unsloth, err := registry.Get(ctx, PresetUnslothLoRASFT)
+	if err != nil {
+		t.Fatalf("get unsloth preset: %v", err)
+	}
+	if unsloth.PresetID() != PresetUnslothLoRASFT {
+		t.Fatalf("got preset id %q, want %q", unsloth.PresetID(), PresetUnslothLoRASFT)
+	}
+}
+
+func TestStaticRegistryReturnsNotFoundForUnknownID(t *testing.T) {
+	_, err := NewPhase0Registry().Get(context.Background(), ID("missing"))
+	if err == nil {
+		t.Fatalf("expected error for unknown preset")
+	}
+	if !errors.Is(err, errordef.ErrNotFound) {
+		t.Fatalf("got error %v, want not_found", err)
+	}
+}
+
+func TestStaticRegistryListIsOrderedByID(t *testing.T) {
+	got, err := NewPhase0Registry().List(context.Background())
+	if err != nil {
+		t.Fatalf("list presets: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d presets, want 2", len(got))
+	}
+	if got[0].PresetID() != PresetAxolotlLoRASFT || got[1].PresetID() != PresetUnslothLoRASFT {
+		t.Fatalf("got preset order %q, %q", got[0].PresetID(), got[1].PresetID())
+	}
+}
+
+func TestTrainerPresetReturnsCopies(t *testing.T) {
+	trainerPreset := AxolotlLoRASFT()
+
+	defaults := trainerPreset.Defaults()
+	defaults["learning_rate"] = 9.9
+	if got := trainerPreset.Defaults()["learning_rate"]; got == 9.9 {
+		t.Fatalf("mutating returned defaults changed preset defaults")
+	}
+
+	policy := trainerPreset.OptionPolicy()
+	policy.Rules["learning_rate"] = OptionRule{Type: OptionString}
+	if got := trainerPreset.OptionPolicy().Rules["learning_rate"].Type; got != OptionFloat {
+		t.Fatalf("got rule type %q, want %q", got, OptionFloat)
+	}
+
+	policy = trainerPreset.OptionPolicy()
+	*policy.Rules["learning_rate"].Max = 9.9
+	if got := *trainerPreset.OptionPolicy().Rules["learning_rate"].Max; got == 9.9 {
+		t.Fatalf("mutating returned policy bounds changed preset policy")
+	}
+}


### PR DESCRIPTION
## Issue

Part of #9

**Problem**: The request and persistence contract needs a typed preset domain model and ID-based lookup before RunSpec processing can use presets safely.

## Solution

**Approach**: Add a manager preset package with structured trainer fixtures, option policy data, and a static registry behind an interface-friendly shape.

### Changes
- `internal/manager/preset/preset.go` — defines `Preset`, `TrainerPreset`, runtime spec, defaults, and option policy types.
- `internal/manager/preset/fixtures.go` — adds Phase 0 Axolotl and Unsloth LoRA SFT trainer preset data.
- `internal/manager/preset/registry.go` — adds ID-based static registry.
- `internal/manager/preset/registry_test.go` — covers lookup, unknown IDs, ordering, and defensive copies.

### Key Decisions
| Decision | Why |
|----------|-----|
| Keep policy as data | Validator internals are intentionally a later issue. |
| Registry lookup by preset ID | Stable identity should not depend on display labels. |

## What I learned
Learning notes cover interface boundaries, type aliases, and defensive copy patterns for fixture-backed registries.
See: `docs/learn/0009-preset-domain-registry/`

## Test Plan
- [x] `go test ./... -v`
- [x] `gofmt -l .`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`