### PR TITLE
feat(runspec): add preset backed processor

### DIFF
--- a/docs/learn/0010-runspec-processor-finalizer/README.md
+++ b/docs/learn/0010-runspec-processor-finalizer/README.md
@@ -1,0 +1,28 @@
+# RunSpec Processor Finalizer
+
+PR: #27
+Date: 2026-05-09
+
+## What was done
+
+- `runspec.Processor` interface와 `PresetBackedProcessor` 구현을 추가했다.
+- `PresetRegistry`와 `Validator`를 interface로 받아 concrete preset implementation에 직접 의존하지 않게 했다.
+- trainer preset defaults와 request parameters를 merge하는 finalized structured result를 추가했다.
+
+## Categories
+
+- [Code Design](./code-design.md)
+- [Go Programming](./go.md)
+
+## Key decisions
+
+| Decision | Why | Alternatives considered |
+|----------|-----|-------------------------|
+| processor를 submission mode별로 분리 | preset-backed path와 raw/custom path의 전제가 다르기 때문 | 하나의 processor 안에서 nil preset 분기 |
+| validator는 validation만 담당 | finalize orchestration은 processor 책임으로 두기 위해 | validator가 finalized config 생성 |
+| finalized output은 YAML이 아닌 structured data | trainer materialization 이전 단계의 source of truth를 보존하기 위해 | `resolved_config.yaml` 생성 |
+
+## Further study
+
+- [ ] raw/custom submission processor가 어떤 입력 contract를 가져야 하는지 설계
+- [ ] validator issue에서 `OptionPolicy`의 type/range 검증을 어떤 error shape로 반환할지 정리

--- a/docs/learn/0010-runspec-processor-finalizer/code-design.md
+++ b/docs/learn/0010-runspec-processor-finalizer/code-design.md
@@ -1,0 +1,18 @@
+# Code Design
+
+## Processor는 Orchestration Layer
+
+`PresetBackedProcessor`는 registry lookup, validation 호출, finalize 호출의 순서를 조율한다. 직접 validation rule을 구현하지 않고 `Validator` interface에 맡기기 때문에 validator 내부 구현은 별도 issue로 미룰 수 있다.
+
+이 분리는 "검증이 성공했다면 어떤 finalized output을 만들 것인가"와 "입력이 policy를 만족하는가"를 독립적으로 테스트하게 해준다.
+
+## Preset-Backed와 Raw Submission의 분리
+
+`preset_refs.trainer`가 없는 제출은 preset-backed processor의 optional branch가 아니라 다른 processor의 책임으로 남긴다. 이렇게 하면 preset-backed processor는 trainer preset이 필요하다는 전제를 명확히 갖고, missing trainer preset을 오류로 처리할 수 있다.
+
+상위 API layer는 제출 모드에 맞는 processor를 선택하면 된다. processor 내부에서 모든 submission mode를 처리하려 하면 nullable field와 조건문이 계속 늘어난다.
+
+## Finalized Structured Data
+
+`FinalizedRunSpec`은 YAML byte가 아니라 typed struct다. 이 단계에서는 manager가 이해할 수 있는 data model을 유지하고, 특정 trainer runtime이 요구하는 파일 포맷은 더 아래 materialization 단계에서 처리하는 편이 책임 경계가 선명하다.
+

--- a/docs/learn/0010-runspec-processor-finalizer/go.md
+++ b/docs/learn/0010-runspec-processor-finalizer/go.md
@@ -1,0 +1,24 @@
+# Go Programming
+
+## Interface Dependency
+
+`PresetBackedProcessor`는 concrete registry나 validator가 아니라 interface에 의존한다.
+
+```go
+type PresetRegistry interface {
+	Get(ctx context.Context, id preset.ID) (preset.Preset, error)
+}
+
+type Validator interface {
+	Validate(ctx context.Context, spec *run.Spec, p preset.Preset) error
+}
+```
+
+이 형태는 테스트에서 fake registry와 fake validator를 쉽게 주입할 수 있게 한다. production에서는 static registry에서 DB-backed registry로 바뀌어도 processor의 생성자만 달라지면 된다.
+
+## Deterministic JSON
+
+Go map iteration order는 안정적이지 않다. finalized result를 비교하거나 fingerprint로 쓰려면 canonical JSON이 필요하다. `CanonicalJSON`은 struct를 JSON으로 marshal/unmarshal한 뒤 key를 정렬하는 encoder를 사용해 반복 가능한 문자열을 만든다.
+
+이 함수는 finalized output의 deterministic representation을 확인하는 테스트에서 사용된다.
+

--- a/internal/manager/runspec/errors.go
+++ b/internal/manager/runspec/errors.go
@@ -1,0 +1,32 @@
+package runspec
+
+import "strings"
+
+// ValidationError describes one RunSpec validation failure.
+type ValidationError struct {
+	Field  string
+	Reason string
+}
+
+// ValidationErrors is an aggregated validation error list.
+type ValidationErrors []ValidationError
+
+// HasAny reports whether the list contains at least one validation error.
+func (e ValidationErrors) HasAny() bool {
+	return len(e) > 0
+}
+
+func (e ValidationErrors) Error() string {
+	if len(e) == 0 {
+		return "validation failed"
+	}
+	parts := make([]string, 0, len(e))
+	for _, item := range e {
+		if item.Field == "" {
+			parts = append(parts, item.Reason)
+			continue
+		}
+		parts = append(parts, item.Field+": "+item.Reason)
+	}
+	return "validation failed: " + strings.Join(parts, "; ")
+}

--- a/internal/manager/runspec/finalize.go
+++ b/internal/manager/runspec/finalize.go
@@ -1,0 +1,79 @@
+package runspec
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/run"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/preset"
+)
+
+// FinalizedRunSpec is the immutable structured input produced after RunSpec processing.
+type FinalizedRunSpec struct {
+	SpecID          uuid.UUID               `json:"spec_id"`
+	ProjectID       uuid.UUID               `json:"project_id"`
+	Name            string                  `json:"name"`
+	Description     string                  `json:"description,omitempty"`
+	ModelOptions    run.ModelOptions        `json:"model_options"`
+	DataOptions     run.DataOptions         `json:"data_options"`
+	ResourceOptions run.ResourceOptions     `json:"resource_options"`
+	TrainerPresetID preset.ID               `json:"trainer_preset_id"`
+	TrainingConfig  FinalizedTrainingConfig `json:"training_config"`
+}
+
+// FinalizedTrainingConfig is the structured training config that runtime adapters may materialize.
+type FinalizedTrainingConfig struct {
+	Values map[string]any `json:"values"`
+}
+
+// FinalizeRunSpec applies preset defaults and user parameters to create finalized data.
+func FinalizeRunSpec(spec *run.Spec, trainerPreset preset.Preset) FinalizedRunSpec {
+	values := trainerPreset.Defaults()
+	if values == nil {
+		values = make(map[string]any)
+	}
+	for key, value := range spec.TrainingOptions.Parameters {
+		values[key] = cloneFinalizedValue(value)
+	}
+
+	return FinalizedRunSpec{
+		SpecID:          spec.ID,
+		ProjectID:       spec.ProjectID,
+		Name:            spec.Name,
+		Description:     spec.Description,
+		ModelOptions:    spec.ModelOptions,
+		DataOptions:     spec.DataOptions,
+		ResourceOptions: spec.ResourceOptions,
+		TrainerPresetID: trainerPreset.PresetID(),
+		TrainingConfig:  FinalizedTrainingConfig{Values: values},
+	}
+}
+
+// CanonicalJSON returns deterministic JSON for comparison and idempotency checks.
+func CanonicalJSON(finalized *FinalizedRunSpec) (string, error) {
+	data, err := json.Marshal(finalized)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize finalized spec %s: %w", finalized.SpecID, err)
+	}
+	return string(data), nil
+}
+
+func cloneFinalizedValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(typed))
+		for key, item := range typed {
+			cloned[key] = cloneFinalizedValue(item)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneFinalizedValue(item)
+		}
+		return cloned
+	default:
+		return value
+	}
+}

--- a/internal/manager/runspec/finalize_test.go
+++ b/internal/manager/runspec/finalize_test.go
@@ -1,0 +1,99 @@
+package runspec
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/run"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/preset"
+)
+
+func TestFinalizeRunSpecMergesDefaultsAndParameters(t *testing.T) {
+	spec := sampleSpec()
+	trainerPreset := preset.AxolotlLoRASFT()
+
+	finalized := FinalizeRunSpec(&spec, &trainerPreset)
+
+	if finalized.TrainerPresetID != preset.PresetAxolotlLoRASFT {
+		t.Fatalf("got trainer preset id %q, want %q", finalized.TrainerPresetID, preset.PresetAxolotlLoRASFT)
+	}
+	values := finalized.TrainingConfig.Values
+	if got := values["learning_rate"]; got != 2.0e-4 {
+		t.Fatalf("got learning_rate %v, want parameter 2.0e-4", got)
+	}
+	if got := values["lora_r"]; got != 32 {
+		t.Fatalf("got lora_r %v, want parameter 32", got)
+	}
+	if got := values["lora_alpha"]; got != 32 {
+		t.Fatalf("got lora_alpha %v, want default 32", got)
+	}
+}
+
+func TestFinalizeRunSpecDoesNotMutatePresetDefaults(t *testing.T) {
+	spec := sampleSpec()
+	trainerPreset := preset.AxolotlLoRASFT()
+
+	_ = FinalizeRunSpec(&spec, &trainerPreset)
+
+	if got := trainerPreset.Defaults()["lora_r"]; got != 16 {
+		t.Fatalf("got preset default lora_r %v, want unchanged 16", got)
+	}
+}
+
+func TestCanonicalJSONIsDeterministic(t *testing.T) {
+	spec := sampleSpec()
+	trainerPreset := preset.AxolotlLoRASFT()
+
+	finalized := FinalizeRunSpec(&spec, &trainerPreset)
+	first, err := CanonicalJSON(&finalized)
+	if err != nil {
+		t.Fatalf("canonical json: %v", err)
+	}
+	for i := 0; i < 100; i++ {
+		finalized := FinalizeRunSpec(&spec, &trainerPreset)
+		got, err := CanonicalJSON(&finalized)
+		if err != nil {
+			t.Fatalf("canonical json iteration %d: %v", i, err)
+		}
+		if got != first {
+			t.Fatalf("canonical json changed on iteration %d:\nfirst: %s\ngot:   %s", i, first, got)
+		}
+	}
+}
+
+func sampleSpec() run.Spec {
+	return run.Spec{
+		ID:          uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		ProjectID:   uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		Name:        "mergeowl-exp-42",
+		Description: "LoRA SFT experiment",
+		Presets: run.PresetRefs{
+			Trainer: runPresetIDPtr(preset.PresetAxolotlLoRASFT),
+		},
+		ModelOptions: run.ModelOptions{
+			BaseModel: "unsloth/Llama-3.1-8B",
+		},
+		DataOptions: run.DataOptions{
+			Datasets: []run.DatasetRef{
+				{Path: "mergeowl/v1", Split: "train"},
+			},
+		},
+		ResourceOptions: run.ResourceOptions{
+			GPU:     run.GPUOptions{Count: 1},
+			Memory:  run.MemoryOptions{LimitBytes: 34359738368},
+			Timeout: run.TimeoutOptions{DurationSeconds: 14400},
+		},
+		TrainingOptions: run.TrainingOptions{
+			Parameters: map[string]any{
+				"learning_rate":  2.0e-4,
+				"lora_r":         32,
+				"max_seq_length": 4096,
+				"num_epochs":     3,
+			},
+		},
+	}
+}
+
+func runPresetIDPtr(id run.PresetID) *run.PresetID {
+	return &id
+}

--- a/internal/manager/runspec/processor.go
+++ b/internal/manager/runspec/processor.go
@@ -1,0 +1,64 @@
+package runspec
+
+import (
+	"context"
+
+	"github.com/seedspirit/nano-backend.ai/internal/common/run"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/preset"
+)
+
+// Processor finalizes a submitted RunSpec for one submission mode.
+type Processor interface {
+	Process(ctx context.Context, spec *run.Spec) (FinalizedRunSpec, error)
+}
+
+// PresetRegistry is the preset lookup dependency consumed by PresetBackedProcessor.
+type PresetRegistry interface {
+	Get(ctx context.Context, id preset.ID) (preset.Preset, error)
+}
+
+// Validator validates a submitted RunSpec against a preset contract.
+type Validator interface {
+	Validate(spec *run.Spec, trainerPreset preset.Preset) ValidationErrors
+}
+
+// PresetBackedProcessor orchestrates preset lookup, validation, and finalization.
+type PresetBackedProcessor struct {
+	Registry  PresetRegistry
+	Validator Validator
+}
+
+// Process validates and finalizes a submitted RunSpec.
+func (p PresetBackedProcessor) Process(ctx context.Context, spec *run.Spec) (FinalizedRunSpec, error) {
+	if p.Registry == nil {
+		return FinalizedRunSpec{}, errordef.Errorf(errordef.InvalidInput, "preset registry is nil")
+	}
+	if p.Validator == nil {
+		return FinalizedRunSpec{}, errordef.Errorf(errordef.InvalidInput, "runspec validator is nil")
+	}
+
+	presetID, err := ExtractTrainerPresetID(spec)
+	if err != nil {
+		return FinalizedRunSpec{}, err
+	}
+	trainerPreset, err := p.Registry.Get(ctx, presetID)
+	if err != nil {
+		return FinalizedRunSpec{}, err
+	}
+	if validationErrs := p.Validator.Validate(spec, trainerPreset); validationErrs.HasAny() {
+		return FinalizedRunSpec{}, validationErrs
+	}
+	return FinalizeRunSpec(spec, trainerPreset), nil
+}
+
+// ExtractTrainerPresetID reads the trainer preset selector from preset refs.
+func ExtractTrainerPresetID(spec *run.Spec) (preset.ID, error) {
+	if spec == nil {
+		return "", errordef.Errorf(errordef.InvalidInput, "spec is nil")
+	}
+	if spec.Presets.Trainer == nil || *spec.Presets.Trainer == "" {
+		return "", errordef.Errorf(errordef.InvalidInput, "preset_refs.trainer is required")
+	}
+	return preset.ID(*spec.Presets.Trainer), nil
+}

--- a/internal/manager/runspec/processor_test.go
+++ b/internal/manager/runspec/processor_test.go
@@ -1,0 +1,147 @@
+package runspec
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/run"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/preset"
+)
+
+func TestPresetBackedProcessorOrchestratesLookupValidationAndFinalize(t *testing.T) {
+	ctx := context.Background()
+	spec := sampleSpec()
+	trainerPreset := preset.AxolotlLoRASFT()
+	registry := &recordingRegistry{
+		presets: map[preset.ID]preset.Preset{
+			preset.PresetAxolotlLoRASFT: &trainerPreset,
+		},
+	}
+	validator := &recordingValidator{}
+	processor := PresetBackedProcessor{
+		Registry:  registry,
+		Validator: validator,
+	}
+
+	finalized, err := processor.Process(ctx, &spec)
+	if err != nil {
+		t.Fatalf("process runspec: %v", err)
+	}
+
+	if registry.requestedID != preset.PresetAxolotlLoRASFT {
+		t.Fatalf("got registry id %q, want %q", registry.requestedID, preset.PresetAxolotlLoRASFT)
+	}
+	if !validator.called {
+		t.Fatalf("validator was not called")
+	}
+	if validator.spec.ID != spec.ID {
+		t.Fatalf("validator got spec id %s, want %s", validator.spec.ID, spec.ID)
+	}
+	if validator.presetID != preset.PresetAxolotlLoRASFT {
+		t.Fatalf("validator got preset id %q, want %q", validator.presetID, preset.PresetAxolotlLoRASFT)
+	}
+	if finalized.SpecID != spec.ID {
+		t.Fatalf("got finalized spec id %s, want %s", finalized.SpecID, spec.ID)
+	}
+}
+
+func TestPresetBackedProcessorStopsOnValidationErrors(t *testing.T) {
+	spec := sampleSpec()
+	trainerPreset := preset.AxolotlLoRASFT()
+	processor := PresetBackedProcessor{
+		Registry: &recordingRegistry{
+			presets: map[preset.ID]preset.Preset{
+				preset.PresetAxolotlLoRASFT: &trainerPreset,
+			},
+		},
+		Validator: &recordingValidator{
+			errs: ValidationErrors{
+				{Field: "training_options.parameters.lora_r", Reason: "out of range"},
+			},
+		},
+	}
+
+	finalized, err := processor.Process(context.Background(), &spec)
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	var validationErrs ValidationErrors
+	if !errors.As(err, &validationErrs) {
+		t.Fatalf("got error %T %v, want ValidationErrors", err, err)
+	}
+	if finalized.SpecID != uuid.Nil {
+		t.Fatalf("got finalized output %+v, want zero value", finalized)
+	}
+}
+
+func TestPresetBackedProcessorReturnsRegistryError(t *testing.T) {
+	spec := sampleSpec()
+	processor := PresetBackedProcessor{
+		Registry:  &recordingRegistry{err: errordef.ErrNotFound},
+		Validator: &recordingValidator{},
+	}
+
+	_, err := processor.Process(context.Background(), &spec)
+	if err == nil {
+		t.Fatalf("expected registry error")
+	}
+	if !errors.Is(err, errordef.ErrNotFound) {
+		t.Fatalf("got error %v, want not_found", err)
+	}
+}
+
+func TestExtractTrainerPresetID(t *testing.T) {
+	spec := sampleSpec()
+
+	got, err := ExtractTrainerPresetID(&spec)
+	if err != nil {
+		t.Fatalf("extract preset id: %v", err)
+	}
+	if got != preset.PresetAxolotlLoRASFT {
+		t.Fatalf("got preset id %q, want %q", got, preset.PresetAxolotlLoRASFT)
+	}
+}
+
+func TestExtractTrainerPresetIDRejectsMissingSelector(t *testing.T) {
+	spec := sampleSpec()
+	spec.Presets.Trainer = nil
+
+	_, err := ExtractTrainerPresetID(&spec)
+	if err == nil {
+		t.Fatalf("expected missing preset selector error")
+	}
+	if !errors.Is(err, errordef.ErrInvalidInput) {
+		t.Fatalf("got error %v, want invalid_input", err)
+	}
+}
+
+type recordingRegistry struct {
+	presets     map[preset.ID]preset.Preset
+	requestedID preset.ID
+	err         error
+}
+
+func (r *recordingRegistry) Get(_ context.Context, id preset.ID) (preset.Preset, error) {
+	r.requestedID = id
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.presets[id], nil
+}
+
+type recordingValidator struct {
+	called   bool
+	spec     *run.Spec
+	presetID preset.ID
+	errs     ValidationErrors
+}
+
+func (v *recordingValidator) Validate(spec *run.Spec, trainerPreset preset.Preset) ValidationErrors {
+	v.called = true
+	v.spec = spec
+	v.presetID = trainerPreset.PresetID()
+	return v.errs
+}


### PR DESCRIPTION
## Issue

Resolves #9

**Problem**: Preset-backed submissions need a processor layer that can combine request parameters with a selected trainer preset without placing validation or YAML generation in the wrong layer.

## Solution

**Approach**: Add a `runspec.Processor` abstraction and a preset-backed implementation that performs registry lookup, validator delegation, and structured finalization.

### Changes
- `internal/manager/runspec/processor.go` — adds processor, registry, validator interfaces and preset-backed orchestration.
- `internal/manager/runspec/finalize.go` — adds finalized structured result and deterministic JSON helper.
- `internal/manager/runspec/errors.go` — adds minimal processing errors.
- `internal/manager/runspec/*_test.go` — covers success and error paths.

### Key Decisions
| Decision | Why |
|----------|-----|
| Preset-backed processor requires `preset_refs.trainer` | Raw/custom submissions should use a separate processor. |
| Validator only validates | Finalization stays in the processor/finalizer layer. |
| Return structured finalized data | YAML materialization is intentionally out of scope. |

## What I learned
Learning notes describe processor orchestration, interface dependencies, and deterministic finalized output.
See: `docs/learn/0010-runspec-processor-finalizer/`

## Test Plan
- [x] `go test ./... -v`
- [x] `gofmt -l .`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`