### PR TITLE
feat: Standardize response envelope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,21 @@ See `README.md` for project overview, architecture, and tech stack.
 
 ## API Response Conventions
 
-All external API responses use structured JSON:
+All external API responses use a structured JSON envelope:
 
 ```json
-{ "status": "...", "reason": "...", "next_action_hint": "..." }
+{ "status": 200, "data": {} }
 ```
 
-No unstructured text in API responses. Long-running operations return a pollable job ID.
+```json
+{ "status": 404, "error": { "code": "...", "message": "...", "details": {}, "next_action_hint": "..." } }
+```
+
+`status` mirrors the HTTP status code. Machine-readable response fields must be
+stable: HTTP status, endpoint-specific `data`, and `error.code`. Human-readable
+fields such as `error.message` and `error.next_action_hint` are supporting
+context, not client branching keys. Long-running operations return a pollable
+job ID in `data`.
 
 ## Dependency Rules
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Use `.claude/skills/README.md` for the available project workflows and skills.
 
 ## API Design Philosophy
 
-AI agents are the primary consumer. Responses should be machine-readable first: structured JSON, explicit statuses, stable error reasons, and clear next-step hints where useful.
+AI agents are the primary consumer. Responses should be machine-readable first:
+structured JSON envelopes, endpoint-specific `data` payloads, explicit statuses,
+stable `error.code` values, and clear next-step hints where useful.
 
 Long-running operations expose pollable resources. For Phase 0, logs use cursor-based polling rather than WebSockets.
 

--- a/SPEC-ko.md
+++ b/SPEC-ko.md
@@ -341,8 +341,11 @@ GET /runs/{id}/logs?stream=stdout&cursor=1234&limit=200
 Response:
 ```json
 {
-  "next_cursor": 1456,
-  "lines": ["...", "..."]
+  "status": 200,
+  "data": {
+    "next_cursor": 1456,
+    "lines": ["...", "..."]
+  }
 }
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -341,8 +341,11 @@ GET /runs/{id}/logs?stream=stdout&cursor=1234&limit=200
 Response:
 ```json
 {
-  "next_cursor": 1456,
-  "lines": ["...", "..."]
+  "status": 200,
+  "data": {
+    "next_cursor": 1456,
+    "lines": ["...", "..."]
+  }
 }
 ```
 

--- a/epic-issue-ko.md
+++ b/epic-issue-ko.md
@@ -91,7 +91,7 @@ RunSpec
 
 - Task: Validation, idempotent retry, conflict handling을 포함한 `POST /runs` 구현.
 - Task: 전체 run state, timestamp, failure reason, artifact path를 반환하는 `GET /runs/{id}` 구현.
-- Task: `status`, `reason`, `next_action_hint`를 포함하는 API error 표준화.
+- Task: HTTP code `status`, 성공 `data` payload와 에러 `{code, message, details, next_action_hint}` payload를 포함하는 API response 표준화.
 
 ### Story 1.5: Project별 Run 목록 조회
 

--- a/epic-issue.md
+++ b/epic-issue.md
@@ -91,7 +91,7 @@ RunSpec
 
 - Task: Implement `POST /runs` with validation, idempotent retry, and conflict handling.
 - Task: Implement `GET /runs/{id}` with full run state, timestamps, failure reason, and artifact path.
-- Task: Standardize API errors with `status`, `reason`, and `next_action_hint`.
+- Task: Standardize API responses with HTTP-code `status`, success `data` payloads, and error `{code, message, details, next_action_hint}` payloads.
 
 ### Story 1.5: List Runs for a Project
 

--- a/internal/common/response/response.go
+++ b/internal/common/response/response.go
@@ -1,40 +1,62 @@
 // Package response defines the standard envelope for external API responses.
 package response
 
-// Status represents the outcome status of an API response.
-type Status string
+import "net/http"
 
-// API status constants.
-const (
-	StatusOK    Status = "ok"
-	StatusError Status = "error"
-)
+// Error is the standard error payload for external API responses.
+//
+// Code is the stable machine-readable value clients should branch on. Message
+// and NextActionHint are explanatory text for humans and agents.
+type Error struct {
+	Code           string `json:"code"`
+	Message        string `json:"message,omitempty"`
+	Details        any    `json:"details,omitempty"`
+	NextActionHint string `json:"next_action_hint,omitempty"`
+}
 
 // Response is the standard API response envelope.
-// All external API responses use this structure:
+// Successful responses carry endpoint-specific payloads in Data:
 //
-//	{"status": "...", "reason": "...", "next_action_hint": "..."}
+//	{"status": 200, "data": {...}}
+//
+// Error responses carry stable error codes in Error:
+//
+//	{"status": 404, "error": {"code": "...", "message": "..."}}
 type Response struct {
-	Status         Status `json:"status"`
-	Reason         string `json:"reason"`
-	NextActionHint string `json:"next_action_hint"`
+	Status int    `json:"status"`
+	Data   any    `json:"data,omitempty"`
+	Error  *Error `json:"error,omitempty"`
 }
 
 // New creates a Response with all fields set.
-func New(status Status, reason, nextActionHint string) Response {
+func New(statusCode int, data any, err *Error) Response {
 	return Response{
-		Status:         status,
-		Reason:         reason,
-		NextActionHint: nextActionHint,
+		Status: statusCode,
+		Data:   data,
+		Error:  err,
 	}
 }
 
-// OK creates a successful Response with status "ok".
-func OK(reason, nextActionHint string) Response {
-	return New(StatusOK, reason, nextActionHint)
+// OK creates a successful Response with HTTP 200 status.
+func OK(data any) Response {
+	return Success(http.StatusOK, data)
 }
 
-// Err creates an error Response with status "error".
-func Err(reason, nextActionHint string) Response {
-	return New(StatusError, reason, nextActionHint)
+// Success creates a successful Response with the given HTTP status code.
+func Success(statusCode int, data any) Response {
+	if data == nil {
+		data = map[string]any{}
+	}
+
+	return New(statusCode, data, nil)
+}
+
+// Err creates an error Response with the given HTTP status code.
+func Err(statusCode int, code, message, nextActionHint string, details any) Response {
+	return New(statusCode, nil, &Error{
+		Code:           code,
+		Message:        message,
+		Details:        details,
+		NextActionHint: nextActionHint,
+	})
 }

--- a/internal/common/response/response_test.go
+++ b/internal/common/response/response_test.go
@@ -2,78 +2,153 @@ package response
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
 )
 
 func TestNewSetsAllFields(t *testing.T) {
-	resp := New("healthy", "service is running", "proceed with requests")
+	errPayload := &Error{Code: "validation_error", Message: "missing field"}
+	resp := New(http.StatusUnprocessableEntity, nil, errPayload)
 
-	if resp.Status != "healthy" {
-		t.Errorf("got status %q, want %q", resp.Status, Status("healthy"))
+	if resp.Status != http.StatusUnprocessableEntity {
+		t.Errorf("got status %d, want %d", resp.Status, http.StatusUnprocessableEntity)
 	}
-	if resp.Reason != "service is running" {
-		t.Errorf("got reason %q, want %q", resp.Reason, "service is running")
+	if resp.Data != nil {
+		t.Errorf("got data %v, want nil", resp.Data)
 	}
-	if resp.NextActionHint != "proceed with requests" {
-		t.Errorf("got next_action_hint %q, want %q", resp.NextActionHint, "proceed with requests")
+	if resp.Error != errPayload {
+		t.Errorf("got error %v, want original error payload", resp.Error)
 	}
 }
 
 func TestOKSetsStatusToOK(t *testing.T) {
-	resp := OK("done", "continue")
+	resp := OK(map[string]string{"state": "healthy"})
 
-	if resp.Status != StatusOK {
-		t.Errorf("got status %q, want %q", resp.Status, StatusOK)
+	if resp.Status != http.StatusOK {
+		t.Errorf("got status %d, want %d", resp.Status, http.StatusOK)
+	}
+	if resp.Error != nil {
+		t.Errorf("got error %v, want nil", resp.Error)
 	}
 }
 
-func TestErrSetsStatusToError(t *testing.T) {
-	resp := Err("failed", "retry later")
+func TestSuccessUsesGivenStatusCode(t *testing.T) {
+	resp := Success(http.StatusCreated, map[string]string{"id": "run_123"})
 
-	if resp.Status != StatusError {
-		t.Errorf("got status %q, want %q", resp.Status, StatusError)
+	if resp.Status != http.StatusCreated {
+		t.Errorf("got status %d, want %d", resp.Status, http.StatusCreated)
 	}
 }
 
-func TestResponseSerializesToJSON(t *testing.T) {
-	resp := New(StatusOK, "all good", "send requests")
+func TestOKUsesEmptyObjectWhenDataIsNil(t *testing.T) {
+	resp := OK(nil)
 
 	data, err := json.Marshal(resp)
 	if err != nil {
 		t.Fatalf("unexpected marshal error: %v", err)
 	}
 
-	var m map[string]string
+	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
 		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 
-	if m["status"] != "ok" {
-		t.Errorf("got status %q, want %q", m["status"], "ok")
+	if _, ok := m["data"].(map[string]any); !ok {
+		t.Fatalf("got data %T, want object", m["data"])
 	}
-	if m["reason"] != "all good" {
-		t.Errorf("got reason %q, want %q", m["reason"], "all good")
+}
+
+func TestErrSetsStatusToError(t *testing.T) {
+	resp := Err(http.StatusNotFound, "not_found", "run not found", "check the run ID and retry", nil)
+
+	if resp.Status != http.StatusNotFound {
+		t.Errorf("got status %d, want %d", resp.Status, http.StatusNotFound)
 	}
-	if m["next_action_hint"] != "send requests" {
-		t.Errorf("got next_action_hint %q, want %q", m["next_action_hint"], "send requests")
+	if resp.Error == nil {
+		t.Fatal("got nil error payload, want error payload")
+	}
+	if resp.Error.Code != "not_found" {
+		t.Errorf("got code %q, want %q", resp.Error.Code, "not_found")
+	}
+}
+
+func TestResponseSerializesToJSON(t *testing.T) {
+	resp := OK(map[string]string{"state": "healthy"})
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if m["status"] != float64(http.StatusOK) {
+		t.Errorf("got status %v, want %d", m["status"], http.StatusOK)
+	}
+	dataPayload, ok := m["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("got data %T, want object", m["data"])
+	}
+	if dataPayload["state"] != "healthy" {
+		t.Errorf("got state %q, want %q", dataPayload["state"], "healthy")
+	}
+}
+
+func TestErrorResponseSerializesToJSON(t *testing.T) {
+	resp := Err(http.StatusUnprocessableEntity, "validation_error", "missing required field", "provide project_id and retry", map[string]string{
+		"field": "project_id",
+	})
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if m["status"] != float64(http.StatusUnprocessableEntity) {
+		t.Errorf("got status %v, want %d", m["status"], http.StatusUnprocessableEntity)
+	}
+	errorPayload, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("got error %T, want object", m["error"])
+	}
+	if errorPayload["code"] != "validation_error" {
+		t.Errorf("got code %q, want %q", errorPayload["code"], "validation_error")
+	}
+	details, ok := errorPayload["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("got details %T, want object", errorPayload["details"])
+	}
+	if details["field"] != "project_id" {
+		t.Errorf("got field %q, want %q", details["field"], "project_id")
 	}
 }
 
 func TestResponseDeserializesFromJSON(t *testing.T) {
-	input := `{"status":"ok","reason":"done","next_action_hint":"proceed"}`
+	input := `{"status":404,"error":{"code":"not_found","message":"run not found","next_action_hint":"check the run ID and retry"}}`
 
 	var resp Response
 	if err := json.Unmarshal([]byte(input), &resp); err != nil {
 		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 
-	if resp.Status != StatusOK {
-		t.Errorf("got status %q, want %q", resp.Status, StatusOK)
+	if resp.Status != http.StatusNotFound {
+		t.Errorf("got status %d, want %d", resp.Status, http.StatusNotFound)
 	}
-	if resp.Reason != "done" {
-		t.Errorf("got reason %q, want %q", resp.Reason, "done")
+	if resp.Error == nil {
+		t.Fatal("got nil error payload, want error payload")
 	}
-	if resp.NextActionHint != "proceed" {
-		t.Errorf("got next_action_hint %q, want %q", resp.NextActionHint, "proceed")
+	if resp.Error.Code != "not_found" {
+		t.Errorf("got code %q, want %q", resp.Error.Code, "not_found")
+	}
+	if resp.Error.NextActionHint != "check the run ID and retry" {
+		t.Errorf("got next_action_hint %q, want %q", resp.Error.NextActionHint, "check the run ID and retry")
 	}
 }

--- a/internal/manager/app_test.go
+++ b/internal/manager/app_test.go
@@ -25,11 +25,15 @@ func TestHealthReturns200OK(t *testing.T) {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	if resp.Status != "ok" {
-		t.Errorf("got status %q, want %q", resp.Status, "ok")
+	if resp.Status != http.StatusOK {
+		t.Errorf("got response body status %d, want %d", resp.Status, http.StatusOK)
 	}
-	if resp.Reason != "healthy" {
-		t.Errorf("got reason %q, want %q", resp.Reason, "healthy")
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("got data %T, want object", resp.Data)
+	}
+	if data["state"] != "healthy" {
+		t.Errorf("got state %q, want %q", data["state"], "healthy")
 	}
 }
 

--- a/internal/manager/health.go
+++ b/internal/manager/health.go
@@ -8,7 +8,7 @@ import (
 )
 
 func handleHealth(w http.ResponseWriter, _ *http.Request) {
-	resp := response.OK("healthy", "")
+	resp := response.OK(map[string]string{"state": "healthy"})
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

- Replace the previous `{status, reason, next_action_hint}` response shape with a structured envelope that carries success payloads in `data` and errors in `error`.
- Make response body `status` mirror the HTTP status code, and use `error.code` as the stable machine-readable branching field.
- Update health response tests, API guidance docs, SPEC log response examples, and issue-planning docs to match the new convention.

## Why

The previous shape was parseable JSON, but it did not provide a payload slot for successful responses and treated human-oriented fields as if they were machine-readable. This change makes the API contract clearer for clients and future run handlers.

## Validation

- `go test ./...`
