### PR TITLE
docs(manager): add layer guidance

### DIFF
--- a/cmd/manager/CLAUDE.md
+++ b/cmd/manager/CLAUDE.md
@@ -1,0 +1,22 @@
+# Manager Command Layer
+
+This directory is the process entry point for the manager binary.
+
+## Responsibilities
+
+- Configure process-level concerns: logging, root context, signals, and exit behavior.
+- Load runtime configuration.
+- Create the manager application through `internal/manager`.
+- Start the application and coordinate graceful shutdown.
+
+## Constraints
+
+- Keep this layer thin. Do not put route registration, business workflows, persistence logic, or domain processing here.
+- Do not instantiate handlers, services, or repositories directly unless they are part of application construction delegated to `internal/manager`.
+- `os.Exit` is allowed only in this command layer, and only after the application has returned.
+- Contexts created here represent process lifetime. Request-scoped work must use contexts created by the transport layer.
+- Prefer small helper functions such as `run(ctx)` when they make startup and shutdown testable without turning `main` into a composition root.
+
+## Dependency Direction
+
+`cmd/manager` may import `internal/manager`, standard library packages, and configuration/logging helpers. It must not be imported by any internal package.

--- a/docs/learn/0013-manager-layer-guidance/README.md
+++ b/docs/learn/0013-manager-layer-guidance/README.md
@@ -1,0 +1,27 @@
+# Manager Layer Guidance
+
+PR: #32
+Date: 2026-05-21
+
+## What was done
+
+- manager command, application, server, service, repository, and database repository layers에 scoped `CLAUDE.md`를 추가했다.
+- 각 layer의 responsibilities, constraints, dependency direction을 역할 중심으로 정리했다.
+- 특정 transport/database 구현명보다 layer boundary와 ownership 원칙을 우선하도록 문서 표현을 다듬었다.
+
+## Categories
+
+- [Code Design](./code-design.md)
+
+## Key decisions
+
+| Decision | Why | Alternatives considered |
+|----------|-----|-------------------------|
+| Subdirectory `CLAUDE.md` files | Agents can read guidance near the code they edit without bloating the root document | Put every layer rule in root `CLAUDE.md` |
+| Role-focused wording | Guidance should survive implementation changes such as transport or storage swaps | Mention concrete libraries and current implementation details |
+| Directory index in `internal/manager` | The top-level manager package acts as a navigation point for lower layers | Rely only on file tree discovery |
+
+## Further study
+
+- [ ] Add similar scoped guidance for `internal/common` once common package boundaries stabilize.
+- [ ] Review future PRs against these layer constraints and adjust wording when repeated exceptions appear.

--- a/docs/learn/0013-manager-layer-guidance/code-design.md
+++ b/docs/learn/0013-manager-layer-guidance/code-design.md
@@ -1,0 +1,19 @@
+# Code Design
+
+## Scoped Agent Guidance
+
+Root-level guidance is useful for global rules, but layer-specific rules become easier to apply when they live close to the relevant code. Subdirectory `CLAUDE.md` files let an agent discover the local role of a package before editing it.
+
+The important distinction is between policy and implementation detail. These files should say what a layer is responsible for, what it must not know, and which direction dependencies should flow. They should avoid locking the repository into a specific framework, database, or low-level mechanism unless that choice is truly part of the architectural policy.
+
+## Layer Boundaries
+
+The manager stack now has explicit guidance for command, application composition, transport, service, repository contract, and repository implementation layers. Each file describes the allowed knowledge at that layer.
+
+This keeps code review questions sharper. Instead of asking only whether code works, reviewers can ask whether the code belongs in that layer, whether it leaks transport or storage details upward, and whether resource ownership is still symmetric.
+
+## Navigation Index
+
+`internal/manager/CLAUDE.md` includes a short directory index because it is the top of the manager subtree. This gives future agents a lightweight map: use `servers/` for transport, `service/` for use cases, `repository/` for persistence contracts, and implementation subpackages for storage details.
+
+The index is intentionally brief. It should orient contributors without becoming a second architecture document that must be updated for every small implementation change.

--- a/internal/manager/CLAUDE.md
+++ b/internal/manager/CLAUDE.md
@@ -1,0 +1,32 @@
+# Manager Application Layer
+
+This directory owns manager application composition.
+
+## Responsibilities
+
+- Act as the manager composition root: create concrete repositories, services, and servers.
+- Own resource lifecycle for dependencies it creates, including cleanup on partial initialization failures.
+- Keep runtime wiring explicit through constructors and `Args` structs.
+- Provide application-level `Start` and `Stop` behavior.
+
+## Constraints
+
+- This layer may know concrete implementations when it wires the application.
+- Do not put request parsing, route-specific behavior, storage queries, or business workflow logic here.
+- Keep ownership symmetric: when this layer creates a resource, it is also responsible for closing it on startup failure and shutdown.
+- Avoid package-level mutable globals for runtime dependencies.
+- Prefer returning errors from constructors instead of panicking on wiring failures.
+
+## Directory Index
+
+- `servers/` — API transport setup, route registration, middleware, binding, and response writing.
+- `service/` — manager use cases and consumer-owned repository interfaces.
+- `repository/` — persistence-facing contracts and repository registries used during wiring.
+- `repository/db/` — database-backed repository implementations and storage mapping.
+- `runspec/` — domain workflow for turning draft input and presets into finalized specs.
+- `preset/` — manager-owned preset registry and fixture-backed preset data.
+- `errordef/` — stable manager error codes and response-envelope mapping.
+
+## Dependency Direction
+
+This layer may import server, service, repository, and infrastructure implementation packages. Lower layers must not import `internal/manager` for application wiring.

--- a/internal/manager/repository/CLAUDE.md
+++ b/internal/manager/repository/CLAUDE.md
@@ -1,0 +1,20 @@
+# Manager Repository Port Layer
+
+This directory defines persistence-facing manager contracts and repository registries.
+
+## Responsibilities
+
+- Describe repository capabilities used by higher manager layers.
+- Group concrete repository instances for application wiring.
+- Keep persistence contracts small and named around application capabilities.
+
+## Constraints
+
+- Do not put storage queries, schema management, transaction helpers, or implementation-specific record mapping in this package.
+- Do not import service or server packages.
+- Avoid broad repository interfaces that expose methods unused by current services.
+- Prefer capability-oriented methods over storage-shape leakage. Method names and arguments should match application needs, not just persistence layout.
+
+## Dependency Direction
+
+Repository port packages may import common domain types. Concrete implementations live in subpackages such as `repository/db` and may satisfy these contracts implicitly.

--- a/internal/manager/repository/db/CLAUDE.md
+++ b/internal/manager/repository/db/CLAUDE.md
@@ -1,0 +1,23 @@
+# Manager Database Repository Layer
+
+This directory contains database-backed repository implementations.
+
+## Responsibilities
+
+- Open and prepare database connections.
+- Implement repository capabilities using storage queries and record mapping.
+- Convert stored records into common domain types.
+- Translate storage-specific absence into manager errors such as `ErrNotFound`.
+
+## Constraints
+
+- Keep storage queries and record structs inside this implementation layer.
+- Do not import service or server packages.
+- Do not expose stored-record structs outside the implementation boundary.
+- Preserve application-facing semantics. For example, if a service asks for data by an application identifier, this layer should translate that into the required storage lookup.
+- Wrap unexpected storage errors with operation context; map expected absence cases to stable manager errors.
+- Keep storage preparation idempotent and covered by tests.
+
+## Dependency Direction
+
+This layer may import common domain types, manager repository port types, manager error definitions, storage libraries, and local implementation packages. It must remain below services and handlers in the dependency graph.

--- a/internal/manager/servers/CLAUDE.md
+++ b/internal/manager/servers/CLAUDE.md
@@ -1,0 +1,28 @@
+# Manager Server Layer
+
+This directory owns API transport setup for the manager.
+
+## Responsibilities
+
+- Configure transport entry points, routing, middleware, binding, and health endpoints.
+- Register versioned API subservers.
+- Translate transport-level inputs into service calls.
+- Write all external responses using the shared response envelope.
+- Own transport lifecycle and graceful shutdown behavior.
+
+## Constraints
+
+- Handlers must stay thin: parse parameters, bind and validate request input, call services, and encode responses.
+- Do not perform storage queries, persistence mutations, or domain finalization directly in handlers.
+- Do not let transport framework types leak into service or repository packages.
+- Use request-scoped contexts for service calls.
+- Keep route groups stable and explicit. Versioned routes belong under versioned route packages.
+- Use manager error definitions for stable error codes rather than endpoint-local ad hoc error payloads.
+
+## Interfaces
+
+Define small consumer-owned service interfaces in handler packages when a handler only needs a subset of service behavior. Constructors should validate required dependencies and return errors for missing wiring.
+
+## Dependency Direction
+
+Server packages may import service packages, common request/response types, and manager error definitions. They must not import concrete repository implementations.

--- a/internal/manager/service/CLAUDE.md
+++ b/internal/manager/service/CLAUDE.md
@@ -1,0 +1,26 @@
+# Manager Service Layer
+
+This directory owns manager use cases.
+
+## Responsibilities
+
+- Coordinate business workflows across domain objects, processors, repositories, and external ports.
+- Define consumer-owned repository interfaces for the persistence capabilities each service needs.
+- Keep use-case operations explicit and small.
+- Return domain or manager errors that handlers can map to response envelopes.
+
+## Constraints
+
+- Services must not import transport framework packages, route packages, or request context wrappers.
+- Services must not depend on concrete storage implementations such as `repository/db`.
+- Services should not know transport details such as path parameters, headers, or JSON field names.
+- Avoid broad service interfaces. Each service package should expose only behavior required by callers.
+- Keep validation and finalization logic in domain-oriented packages when it is reusable outside a single service.
+
+## Interfaces
+
+Place repository interfaces in the service package that consumes them. Include only the methods required by that service. Let concrete repositories satisfy those interfaces implicitly.
+
+## Dependency Direction
+
+Service packages may import common domain types, manager domain processors, repository port packages, and manager error definitions. They must not import server packages or concrete repository implementations.


### PR DESCRIPTION
## Summary

Add scoped `CLAUDE.md` guidance for the manager layers so future agent work has local rules near the code being edited.

## Changes

- `cmd/manager/CLAUDE.md` — command entrypoint responsibilities and constraints
- `internal/manager/CLAUDE.md` — application composition responsibilities, ownership rule, and directory index
- `internal/manager/servers/CLAUDE.md` — transport layer responsibilities and constraints
- `internal/manager/service/CLAUDE.md` — service/use-case responsibilities and interface placement rules
- `internal/manager/repository/CLAUDE.md` — repository port layer responsibilities and constraints
- `internal/manager/repository/db/CLAUDE.md` — database repository implementation layer boundaries
- `docs/learn/0013-manager-layer-guidance/` — learning note for the layer guidance update

## Notes

The guidance intentionally avoids concrete transport or storage implementation details. It focuses on responsibilities, constraints, dependency direction, and ownership boundaries.

## Verification

- `gofmt -l .`
- `golangci-lint run ./...`
- `go test ./...`
- `git diff --cached --check`
