### PR TITLE
refactor(repository): simplify spec row mapping

### DIFF
--- a/docs/learn/0015-simplify-spec-row-mapping/README.md
+++ b/docs/learn/0015-simplify-spec-row-mapping/README.md
@@ -1,0 +1,29 @@
+# Simplify Spec Row Mapping
+
+PR: #34
+Date: 2026-05-21
+
+## What was done
+
+- `RunRepository.GetSpec`가 run ID 기준으로 spec을 직접 조회하도록 단순화했다.
+- 임시 `queryerContext` 추상화를 제거하고 repository receiver 메서드 중심으로 정리했다.
+- DB JSON 컬럼을 entity 내부의 generic scanner로 디코딩하도록 바꿨다.
+
+## Categories
+
+- [Code Design](./code-design.md)
+- [Go Programming](./go.md)
+
+## Key decisions
+
+| Decision | Why | Alternatives considered |
+|----------|-----|-------------------------|
+| Keep `GetSpec` query inline | 현재 사용처가 하나뿐이라 함수 분리가 의도를 더 흐리게 만들었다 | `getSpecByRunID` helper 유지 |
+| Remove `queryerContext` | 지금 단계에서는 테스트 대역이나 트랜잭션 추상화 요구가 없다 | `GetContext`/`SelectContext` 인터페이스 유지 |
+| Put JSON scanner under `entity` | DB scan 동작은 persistence mapping 관심사이므로 domain data 타입에 넣지 않는다 | `spec.*Options`에 `Scan` 구현 |
+
+## Further study
+
+- [ ] `database/sql.Scanner`와 `driver.Valuer`를 함께 쓰는 패턴을 더 살펴보기.
+- [ ] `sqlx`가 struct field를 매핑할 때 scanner를 감지하는 흐름 읽기.
+- [ ] private generic helper가 여러 entity에서 반복될 때 public helper로 올릴 기준 정하기.

--- a/docs/learn/0015-simplify-spec-row-mapping/code-design.md
+++ b/docs/learn/0015-simplify-spec-row-mapping/code-design.md
@@ -1,0 +1,17 @@
+# Code Design
+
+## 필요한 추상화만 남기기
+
+이번 변경에서는 `queryerContext`와 `getSpecByRunID`를 제거했다. 둘 다 일반적으로는 나쁜 구조가 아니지만, 현재 코드에서는 실제 이득보다 간접성이 더 컸다.
+
+추상화는 미래 가능성만으로 두기보다 현재 반복, 변경 압력, 테스트 필요성 중 하나를 해결할 때 힘이 생긴다. 지금 `GetSpec`의 query는 repository 내부에서 한 번만 사용되고, 트랜잭션이나 mock queryer가 필요한 구조도 아니다. 그래서 helper 함수로 분리된 query를 다시 `GetSpec` 안으로 넣는 편이 읽는 사람에게 더 정직하다.
+
+좋은 기준은 "이 이름이 코드보다 더 많은 의미를 주는가?"이다. `getSpecByRunID`는 `GetSpec`과 거의 같은 의미였고, `queryerContext`는 아직 실제 소비자가 없었다. 이럴 때는 구조를 줄이는 편이 낫다.
+
+## 관심사에 맞는 위치 고르기
+
+JSON 컬럼을 Go struct로 읽는 동작은 domain data 자체의 책임이 아니라 DB row mapping의 책임이다. 그래서 `spec.ModelOptions` 같은 순수 데이터 타입에 `Scan`을 구현하지 않고, `entity` 패키지 내부에 `jsonField[T]` wrapper를 만들었다.
+
+이 구조의 장점은 domain 타입이 persistence 기술을 모른다는 점이다. domain data는 JSON 컬럼, SQLite, `database/sql.Scanner`를 몰라도 된다. 반대로 DB entity는 "이 컬럼은 JSON으로 저장되어 있고 읽을 때 특정 타입으로 복원한다"는 저장소 규칙을 명시적으로 가진다.
+
+이런 배치는 layer 의존성도 깔끔하게 만든다. repository/db/entity는 common data 타입을 가져다 저장소 모양으로 감싸지만, common data는 repository/db를 알지 않는다.

--- a/docs/learn/0015-simplify-spec-row-mapping/go.md
+++ b/docs/learn/0015-simplify-spec-row-mapping/go.md
@@ -1,0 +1,32 @@
+# Go Programming
+
+## 암묵적 인터페이스 구현
+
+Go에서는 어떤 타입이 인터페이스를 구현한다고 선언하지 않는다. 필요한 메서드 집합을 가지고 있으면 자동으로 그 인터페이스를 만족한다.
+
+`jsonField[T]`는 `Scan(src any) error` 메서드를 가지므로 `database/sql.Scanner`처럼 사용할 수 있다. `sqlx`는 row를 struct에 채울 때 대상 field가 scanner로 동작할 수 있는지 확인하고, 가능하면 값을 직접 대입하지 않고 `Scan`을 호출한다.
+
+```go
+type jsonField[T any] struct {
+	Data T
+}
+
+func (f *jsonField[T]) Scan(src any) error {
+	// decode DB JSON value into f.Data
+}
+```
+
+이 패턴은 작고 강한 확장 지점을 만든다. 표준 라이브러리나 외부 라이브러리가 기대하는 작은 행동 하나만 구현하면, 커스텀 타입을 기존 흐름에 끼워 넣을 수 있다.
+
+## Generic Wrapper로 반복 줄이기
+
+기존 `Spec.ToSpec`는 option field마다 `encoding.UnmarshalJSON`을 반복했다. `jsonField[T]`는 타입 매개변수 `T`를 사용해서 "JSON 컬럼을 특정 타입으로 읽는다"는 공통 동작을 한 번만 정의한다.
+
+```go
+ModelOptions    jsonField[spec.ModelOptions]    `db:"model_options"`
+DataOptions     jsonField[spec.DataOptions]     `db:"data_options"`
+ResourceOptions jsonField[spec.ResourceOptions] `db:"resource_options"`
+TrainingOptions jsonField[spec.TrainingOptions] `db:"training_options"`
+```
+
+여기서 중요한 점은 generic이 domain 로직을 추상화하는 데 쓰인 것이 아니라, storage decode라는 반복적인 기계 작업을 줄이는 데 쓰였다는 점이다. 이런 종류의 generic은 읽는 사람에게 부담을 크게 주지 않으면서 중복을 줄이기 좋다.

--- a/internal/manager/repository/db/entity/json_field.go
+++ b/internal/manager/repository/db/entity/json_field.go
@@ -1,0 +1,23 @@
+package entity
+
+import (
+	"fmt"
+
+	"github.com/seedspirit/nano-backend.ai/internal/common/encoding"
+)
+
+type jsonField[T any] struct {
+	Data T
+}
+
+// Scan decodes a JSON database field into the typed value.
+func (f *jsonField[T]) Scan(src any) error {
+	switch v := src.(type) {
+	case string:
+		return encoding.UnmarshalJSON(v, &f.Data)
+	case []byte:
+		return encoding.UnmarshalJSON(string(v), &f.Data)
+	default:
+		return fmt.Errorf("scan json field from %T", src)
+	}
+}

--- a/internal/manager/repository/db/entity/spec.go
+++ b/internal/manager/repository/db/entity/spec.go
@@ -6,20 +6,19 @@ import (
 	"github.com/google/uuid"
 	"github.com/seedspirit/nano-backend.ai/internal/common/data/run/preset"
 	"github.com/seedspirit/nano-backend.ai/internal/common/data/run/spec"
-	"github.com/seedspirit/nano-backend.ai/internal/common/encoding"
 )
 
 // Spec is the database record shape for a spec row.
 type Spec struct {
-	ID              string `db:"id"`
-	ProjectID       string `db:"project_id"`
-	Name            string `db:"name"`
-	Description     string `db:"description"`
-	ModelOptions    string `db:"model_options"`
-	DataOptions     string `db:"data_options"`
-	ResourceOptions string `db:"resource_options"`
-	TrainingOptions string `db:"training_options"`
-	CreatedAt       string `db:"created_at"`
+	ID              string                          `db:"id"`
+	ProjectID       string                          `db:"project_id"`
+	Name            string                          `db:"name"`
+	Description     string                          `db:"description"`
+	ModelOptions    jsonField[spec.ModelOptions]    `db:"model_options"`
+	DataOptions     jsonField[spec.DataOptions]     `db:"data_options"`
+	ResourceOptions jsonField[spec.ResourceOptions] `db:"resource_options"`
+	TrainingOptions jsonField[spec.TrainingOptions] `db:"training_options"`
+	CreatedAt       string                          `db:"created_at"`
 	PresetRefs      preset.Refs
 }
 
@@ -35,23 +34,15 @@ func (s *Spec) ToSpec() (spec.Spec, error) {
 	}
 
 	runSpec := spec.Spec{
-		ID:          id,
-		ProjectID:   projectID,
-		Name:        s.Name,
-		Description: s.Description,
-		PresetRefs:  s.PresetRefs,
-	}
-	if err := encoding.UnmarshalJSON(s.ModelOptions, &runSpec.ModelOptions); err != nil {
-		return spec.Spec{}, err
-	}
-	if err := encoding.UnmarshalJSON(s.DataOptions, &runSpec.DataOptions); err != nil {
-		return spec.Spec{}, err
-	}
-	if err := encoding.UnmarshalJSON(s.ResourceOptions, &runSpec.ResourceOptions); err != nil {
-		return spec.Spec{}, err
-	}
-	if err := encoding.UnmarshalJSON(s.TrainingOptions, &runSpec.TrainingOptions); err != nil {
-		return spec.Spec{}, err
+		ID:              id,
+		ProjectID:       projectID,
+		Name:            s.Name,
+		Description:     s.Description,
+		PresetRefs:      s.PresetRefs,
+		ModelOptions:    s.ModelOptions.Data,
+		DataOptions:     s.DataOptions.Data,
+		ResourceOptions: s.ResourceOptions.Data,
+		TrainingOptions: s.TrainingOptions.Data,
 	}
 
 	return runSpec, nil

--- a/internal/manager/repository/db/run.go
+++ b/internal/manager/repository/db/run.go
@@ -14,11 +14,6 @@ import (
 	"github.com/seedspirit/nano-backend.ai/internal/manager/repository/db/entity"
 )
 
-type queryerContext interface {
-	GetContext(ctx context.Context, dest any, query string, args ...any) error
-	SelectContext(ctx context.Context, dest any, query string, args ...any) error
-}
-
 // Args configures the SQLite run repository.
 type Args struct {
 	DBPath string
@@ -45,16 +40,8 @@ func (r *RunRepository) Close() error {
 
 // GetSpec returns the finalized spec for a run.
 func (r *RunRepository) GetSpec(ctx context.Context, runID uuid.UUID) (spec.Spec, error) {
-	row, err := getSpecByRunID(ctx, r.db, runID)
-	if err != nil {
-		return spec.Spec{}, err
-	}
-	return row.ToSpec()
-}
-
-func getSpecByRunID(ctx context.Context, queryer queryerContext, runID uuid.UUID) (entity.Spec, error) {
 	var row entity.Spec
-	err := queryer.GetContext(ctx, &row, `
+	err := r.db.GetContext(ctx, &row, `
 		SELECT specs.id, specs.project_id, specs.name, specs.description,
 			specs.model_options, specs.data_options, specs.resource_options,
 			specs.training_options, specs.created_at
@@ -63,29 +50,30 @@ func getSpecByRunID(ctx context.Context, queryer queryerContext, runID uuid.UUID
 		WHERE runs.id = ?
 	`, runID.String())
 	if errors.Is(err, sql.ErrNoRows) {
-		return entity.Spec{}, errordef.ErrNotFound
+		return spec.Spec{}, errordef.ErrNotFound
 	}
 	if err != nil {
-		return entity.Spec{}, fmt.Errorf("get spec for run %s: %w", runID, err)
+		return spec.Spec{}, fmt.Errorf("get spec for run %s: %w", runID, err)
 	}
 	specID, err := uuid.Parse(row.ID)
 	if err != nil {
-		return entity.Spec{}, fmt.Errorf("parse spec id %q: %w", row.ID, err)
+		return spec.Spec{}, fmt.Errorf("parse spec id %q: %w", row.ID, err)
 	}
-	refs, err := getSpecPresetRefs(ctx, queryer, specID)
+	refs, err := r.getSpecPresetRefs(ctx, specID)
 	if err != nil {
-		return entity.Spec{}, err
+		return spec.Spec{}, err
 	}
 	row.PresetRefs = refs
-	return row, nil
+
+	return row.ToSpec()
 }
 
-func getSpecPresetRefs(ctx context.Context, queryer queryerContext, specID uuid.UUID) (preset.Refs, error) {
+func (r *RunRepository) getSpecPresetRefs(ctx context.Context, specID uuid.UUID) (preset.Refs, error) {
 	var rows []struct {
 		Category string `db:"category"`
 		PresetID string `db:"preset_id"`
 	}
-	if err := queryer.SelectContext(ctx, &rows, `
+	if err := r.db.SelectContext(ctx, &rows, `
 		SELECT category, preset_id
 		FROM spec_preset_refs
 		WHERE spec_id = ?


### PR DESCRIPTION
## Background
The run spec lookup API is now run-oriented, and the repository code had a little more structure than the current behavior needed. This PR keeps the lookup direct while still preserving the DB/entity boundary.

## Changes
- `internal/manager/repository/db/run.go` — inline the run-to-spec lookup into `RunRepository.GetSpec` and remove the temporary queryer abstraction.
- `internal/manager/repository/db/entity/json_field.go` — add an entity-local generic JSON scanner for DB JSON columns.
- `internal/manager/repository/db/entity/spec.go` — use the scanner so `ToSpec` maps already-decoded option values.
- `docs/learn/0015-simplify-spec-row-mapping/` — add submit learning notes for the design and Go concepts.

### Key Decisions
| Decision | Why |
|----------|-----|
| Keep `GetSpec` lookup inline | The helper duplicated the public method's intent and had only one caller. |
| Remove `queryerContext` | There is no current transaction or test-double need that justifies the abstraction. |
| Keep JSON scanning inside `entity` | DB scan behavior belongs to persistence mapping, not pure domain data. |

## What I learned
This PR documents how small Go interfaces such as `database/sql.Scanner` let custom generic wrappers plug into library behavior without making domain types storage-aware.
See: `docs/learn/0015-simplify-spec-row-mapping/`

## Test Coverage Report
### `internal/manager/repository/db`
- ok: `TestGetSpecUsesRunID` covers successful lookup by run ID.
- ok: `TestGetSpecUsesRunID` covers the failure path where a spec ID is passed instead of a run ID and maps to `ErrNotFound`.
- ok: The successful lookup path exercises JSON option decoding through the entity scanner.

## Test Plan
- [x] `go test ./... -v 2>&1`
- [x] `gofmt -l .`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`
- [x] `git diff --check`