### PR TITLE
feat(manager): add project run list API

### DIFF
--- a/docs/learn/0016-project-run-list-api/README.md
+++ b/docs/learn/0016-project-run-list-api/README.md
@@ -1,0 +1,30 @@
+# Project Run List API
+
+PR: #35
+Date: 2026-05-21
+
+## What was done
+
+- `GET /v1/projects/{id}/runs`를 추가해 project별 최근 run 목록을 조회할 수 있게 했다.
+- run list response item을 `RunSummary` DTO로 정의하고 `data={runs, limit}` envelope를 반환했다.
+- SQLite repository에서 project 존재 여부와 최신순 limit query를 함께 처리하도록 확장했다.
+
+## Categories
+
+- [Code Design](./code-design.md)
+- [Go Programming](./go.md)
+- [Backend.AI Architecture](./backend-ai.md)
+
+## Key decisions
+
+| Decision | Why | Alternatives considered |
+|----------|-----|-------------------------|
+| `projectserv`를 새로 추가 | route의 주체가 project이고 handler 책임을 project path parsing과 list response에 한정할 수 있다 | 기존 `runserv`에 project route를 함께 등록 |
+| Repository에서 project 존재 여부 확인 | 빈 project와 미존재 project를 구분하려면 storage boundary에서 같은 DB view로 판단하는 편이 명확하다 | handler나 service에서 별도 project service를 도입 |
+| `RunSummary` DTO 정의 | list API는 navigation용 summary shape가 필요하며 domain `run.Run`을 그대로 외부 응답으로 노출하지 않는다 | `run.Run`을 response data에 직접 사용 |
+
+## Further study
+
+- [ ] `GET /v1/projects/{id}/runs?limit=&cursor=`로 확장할 때 request DTO와 binder 검증 위치 설계하기.
+- [ ] run summary와 future `GET /v1/runs/{id}` summary 응답의 공통 DTO 경계를 정리하기.
+- [ ] Backend.AI Manager에서 session/run list API가 pagination과 project scoping을 다루는 방식 살펴보기.

--- a/docs/learn/0016-project-run-list-api/backend-ai.md
+++ b/docs/learn/0016-project-run-list-api/backend-ai.md
@@ -1,0 +1,23 @@
+# Backend.AI Architecture
+
+## Project 기준 Run 탐색
+
+Backend.AI 계열 시스템에서 사용자는 개별 run ID를 항상 알고 있지 않다. project나 session 그룹에서 최근 실행 목록을 보고, 그 목록에서 특정 run의 상세 정보나 spec으로 이동하는 흐름이 자연스럽다.
+
+이번 API는 그 탐색 흐름의 작은 vertical slice다. project ID를 기준으로 최근 run summary를 반환하고, 각 item은 run ID와 spec ID를 함께 제공한다. client는 이 목록을 통해 `GET /v1/runs/{id}/spec` 같은 run 기준 API로 이어갈 수 있다.
+
+관련 코드:
+
+- `internal/manager/servers/v1serv/projectserv/handler.go`
+- `internal/manager/servers/v1serv/runserv/handler.go`
+
+## Phase 0 pagination 정책
+
+이번 단계에서는 cursor pagination 없이 default limit만 제공한다. response의 `data.limit`에 적용된 limit을 명시해 client가 서버의 기본 조회 크기를 알 수 있게 했다.
+
+이 구조는 이후 cursor pagination을 추가할 여지를 남긴다. `runs` 배열과 `limit`은 유지하고, 필요하면 `next_cursor` 같은 필드를 `ProjectRunsData`에 추가할 수 있다. 중요한 점은 Phase 0에서도 ordering과 limit을 명시해 list semantics를 안정화하는 것이다.
+
+관련 코드:
+
+- `internal/common/dto/response/run.go`
+- `internal/manager/servers/v1serv/projectserv/handler.go`

--- a/docs/learn/0016-project-run-list-api/code-design.md
+++ b/docs/learn/0016-project-run-list-api/code-design.md
@@ -1,0 +1,35 @@
+# Code Design
+
+## Route 주체에 맞는 handler 패키지
+
+이번 API는 run 목록을 반환하지만 route의 주체는 `/projects/{id}`이다. 그래서 `runserv`에 project route를 끼워 넣지 않고 `internal/manager/servers/v1serv/projectserv`를 추가했다.
+
+이 선택은 handler의 책임을 읽기 쉽게 만든다. `projectserv`는 project path parameter를 해석하고 project 기준 use case를 호출한다. `runserv`는 run ID 기준 route만 유지한다. route tree가 커질수록 "URL의 소유자"와 handler package가 일치하는 구조가 더 찾기 쉽다.
+
+관련 코드:
+
+- `internal/manager/servers/v1serv/projectserv/handler.go`
+- `internal/manager/servers/v1serv/projectserv/server.go`
+- `internal/manager/servers/v1serv/server.go`
+
+## DTO로 외부 응답 shape 고정하기
+
+`run.Run`은 application data 타입이고, list API의 item shape는 외부 계약이다. 이번 변경에서는 `response.RunSummary`를 별도로 두어 list API가 필요한 필드만 명시했다.
+
+이렇게 하면 domain data가 바뀌어도 외부 API 응답을 안정적으로 유지할 수 있다. 예를 들어 나중에 `run.Run`에 runtime-only 필드가 추가되어도 summary DTO에 포함하지 않으면 client contract는 흔들리지 않는다. 반대로 summary에 필요한 필드가 생기면 DTO에서 명시적으로 추가한다.
+
+관련 코드:
+
+- `internal/common/dto/response/run.go`
+- `internal/manager/servers/v1serv/projectserv/handler.go`
+
+## 존재 확인과 목록 조회의 경계
+
+이슈의 요구사항은 "run이 없는 project"와 "존재하지 않는 project"를 구분하는 것이다. 이 구분은 DB가 가장 잘 알고 있으므로 `RunRepository.ListProjectRuns`가 먼저 `projects` 존재 여부를 확인하고, 존재하면 `runs`를 최신순으로 조회한다.
+
+service에 별도 validation을 넣지 않은 것도 같은 이유다. 현재 `limit`은 handler의 상수이고 외부 입력이 아니다. 나중에 query parameter가 생기면 request binding과 validation 계층에서 다루고, service는 use case orchestration에 집중하는 편이 계층 책임이 선명하다.
+
+관련 코드:
+
+- `internal/manager/repository/db/run.go`
+- `internal/manager/service/runsvc/run.go`

--- a/docs/learn/0016-project-run-list-api/go.md
+++ b/docs/learn/0016-project-run-list-api/go.md
@@ -1,0 +1,34 @@
+# Go Programming
+
+## Consumer-owned interface 확장
+
+`runsvc.Service`는 concrete DB repository를 직접 알지 않고 자신이 필요한 capability만 interface로 선언한다. 이번 변경에서는 기존 `GetSpec`에 `ListProjectRuns`만 추가했다.
+
+Go에서는 provider가 interface를 명시적으로 구현한다고 선언하지 않는다. DB repository에 같은 method set이 있으면 암묵적으로 service의 interface를 만족한다. 이 방식은 dependency direction을 service -> repository behavior로 유지하면서 concrete storage import를 피하게 해준다.
+
+관련 코드:
+
+- `internal/manager/service/runsvc/run.go`
+- `internal/manager/repository/db/run.go`
+
+## sql.NullString과 pointer field 변환
+
+DB nullable column은 `sql.NullString`으로 scan하고, domain data에서는 `*string`, `*run.FailureReason`, `*time.Time`처럼 nil이 의미 있는 field로 표현한다. `entity.Run.ToRun`은 이 저장소 표현을 application data 표현으로 바꾸는 경계다.
+
+이 변환을 entity layer에 두면 handler나 service는 nullable DB column을 알 필요가 없다. service 이후 계층은 "값이 없으면 nil"이라는 Go data shape만 다루면 된다.
+
+관련 코드:
+
+- `internal/manager/repository/db/entity/run.go`
+- `internal/manager/repository/db/entity/run_test.go`
+
+## 테스트 fixture로 의도 드러내기
+
+repository 테스트에서 raw SQL setup이 테스트 본문에 많아지면 검증하려는 동작이 묻힌다. 이번 변경에서는 `runRepositoryFixture`를 두어 본문에는 `givenProject`, `givenRun`처럼 필요한 상태만 남겼다.
+
+fixture는 숨겨도 되는 반복 setup만 감춘다. 반대로 검증 대상 호출인 `ListProjectRuns`와 기대 순서, limit 검증은 테스트 본문에 그대로 둔다. 이 균형이 테스트를 짧게 만들면서도 실패 시 원인을 추적할 수 있게 한다.
+
+관련 코드:
+
+- `internal/manager/repository/db/run_test.go`
+- `internal/manager/servers/v1serv/projectserv/handler_test.go`

--- a/internal/common/dto/response/run.go
+++ b/internal/common/dto/response/run.go
@@ -1,0 +1,51 @@
+package response
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
+)
+
+// RunSummary is the stable list item shape for run navigation responses.
+type RunSummary struct {
+	ID             uuid.UUID          `json:"id"`
+	ProjectID      uuid.UUID          `json:"project_id"`
+	SpecID         uuid.UUID          `json:"spec_id"`
+	IdempotencyKey *string            `json:"idempotency_key,omitempty"`
+	Status         run.Status         `json:"status"`
+	FailureReason  *run.FailureReason `json:"failure_reason,omitempty"`
+	CreatedAt      time.Time          `json:"created_at"`
+	StartedAt      *time.Time         `json:"started_at,omitempty"`
+	FinishedAt     *time.Time         `json:"finished_at,omitempty"`
+}
+
+// ProjectRunsData is the response data payload for project run lists.
+type ProjectRunsData struct {
+	Runs  []RunSummary `json:"runs"`
+	Limit int          `json:"limit"`
+}
+
+// NewRunSummary converts application run data into the external summary DTO.
+func NewRunSummary(projectID uuid.UUID, source *run.Run) RunSummary {
+	return RunSummary{
+		ID:             source.ID,
+		ProjectID:      projectID,
+		SpecID:         source.SpecID,
+		IdempotencyKey: source.IdempotencyKey,
+		Status:         source.Lifecycle.Status,
+		FailureReason:  source.Lifecycle.FailureReason,
+		CreatedAt:      source.Lifecycle.CreatedAt,
+		StartedAt:      source.Lifecycle.StartedAt,
+		FinishedAt:     source.Lifecycle.FinishedAt,
+	}
+}
+
+// NewRunSummaries converts application run data into external summary DTOs.
+func NewRunSummaries(projectID uuid.UUID, source []run.Run) []RunSummary {
+	summaries := make([]RunSummary, 0, len(source))
+	for i := range source {
+		summaries = append(summaries, NewRunSummary(projectID, &source[i]))
+	}
+	return summaries
+}

--- a/internal/common/dto/response/run_test.go
+++ b/internal/common/dto/response/run_test.go
@@ -1,0 +1,55 @@
+package response
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
+)
+
+func TestNewRunSummariesMapsRunData(t *testing.T) {
+	projectID := uuid.New()
+	runID := uuid.New()
+	specID := uuid.New()
+	createdAt := time.Date(2026, 5, 21, 0, 0, 0, 0, time.UTC)
+
+	got := NewRunSummaries(projectID, []run.Run{{
+		ID:     runID,
+		SpecID: specID,
+		Lifecycle: run.Lifecycle{
+			Status:    run.Queued,
+			CreatedAt: createdAt,
+		},
+	}})
+
+	if len(got) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(got))
+	}
+	if got[0].ID != runID {
+		t.Fatalf("got run id %s, want %s", got[0].ID, runID)
+	}
+	if got[0].ProjectID != projectID {
+		t.Fatalf("got project id %s, want %s", got[0].ProjectID, projectID)
+	}
+	if got[0].SpecID != specID {
+		t.Fatalf("got spec id %s, want %s", got[0].SpecID, specID)
+	}
+	if got[0].Status != run.Queued {
+		t.Fatalf("got status %s, want %s", got[0].Status, run.Queued)
+	}
+	if !got[0].CreatedAt.Equal(createdAt) {
+		t.Fatalf("got created_at %s, want %s", got[0].CreatedAt, createdAt)
+	}
+}
+
+func TestNewRunSummariesReturnsEmptySlice(t *testing.T) {
+	got := NewRunSummaries(uuid.New(), nil)
+
+	if got == nil {
+		t.Fatal("got nil summaries, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d summaries, want 0", len(got))
+	}
+}

--- a/internal/manager/repository/db/entity/run.go
+++ b/internal/manager/repository/db/entity/run.go
@@ -1,0 +1,72 @@
+package entity
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
+	"github.com/seedspirit/nano-backend.ai/internal/common/encoding"
+)
+
+// Run is the database record shape for a run row.
+type Run struct {
+	ID             string         `db:"id"`
+	SpecID         string         `db:"spec_id"`
+	IdempotencyKey sql.NullString `db:"idempotency_key"`
+	Status         string         `db:"status"`
+	FailureReason  sql.NullString `db:"failure_reason"`
+	CreatedAt      string         `db:"created_at"`
+	StartedAt      sql.NullString `db:"started_at"`
+	FinishedAt     sql.NullString `db:"finished_at"`
+}
+
+// ToRun converts the database record into the public run type.
+func (r *Run) ToRun() (run.Run, error) {
+	id, err := uuid.Parse(r.ID)
+	if err != nil {
+		return run.Run{}, fmt.Errorf("parse run id %q: %w", r.ID, err)
+	}
+	specID, err := uuid.Parse(r.SpecID)
+	if err != nil {
+		return run.Run{}, fmt.Errorf("parse spec id %q: %w", r.SpecID, err)
+	}
+	createdAt, err := encoding.ParseTime(r.CreatedAt)
+	if err != nil {
+		return run.Run{}, err
+	}
+
+	lifecycle := run.Lifecycle{
+		Status:    run.Status(r.Status),
+		CreatedAt: createdAt,
+	}
+	if r.FailureReason.Valid {
+		reason := run.FailureReason(r.FailureReason.String)
+		lifecycle.FailureReason = &reason
+	}
+	if r.StartedAt.Valid {
+		startedAt, err := encoding.ParseTime(r.StartedAt.String)
+		if err != nil {
+			return run.Run{}, err
+		}
+		lifecycle.StartedAt = &startedAt
+	}
+	if r.FinishedAt.Valid {
+		finishedAt, err := encoding.ParseTime(r.FinishedAt.String)
+		if err != nil {
+			return run.Run{}, err
+		}
+		lifecycle.FinishedAt = &finishedAt
+	}
+
+	result := run.Run{
+		ID:        id,
+		SpecID:    specID,
+		Lifecycle: lifecycle,
+	}
+	if r.IdempotencyKey.Valid {
+		key := r.IdempotencyKey.String
+		result.IdempotencyKey = &key
+	}
+	return result, nil
+}

--- a/internal/manager/repository/db/entity/run_test.go
+++ b/internal/manager/repository/db/entity/run_test.go
@@ -1,0 +1,78 @@
+package entity
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
+)
+
+func TestRunToRunMapsStoredFields(t *testing.T) {
+	runID := uuid.New()
+	specID := uuid.New()
+	idempotencyKey := "submit-1"
+	failureReason := "runtime_error"
+	row := Run{
+		ID:             runID.String(),
+		SpecID:         specID.String(),
+		IdempotencyKey: sql.NullString{String: idempotencyKey, Valid: true},
+		Status:         string(run.Failed),
+		FailureReason:  sql.NullString{String: failureReason, Valid: true},
+		CreatedAt:      "2026-05-21T00:00:00Z",
+		StartedAt:      sql.NullString{String: "2026-05-21T00:01:00Z", Valid: true},
+		FinishedAt:     sql.NullString{String: "2026-05-21T00:02:00Z", Valid: true},
+	}
+
+	got, err := row.ToRun()
+	if err != nil {
+		t.Fatalf("to run: %v", err)
+	}
+	if got.ID != runID {
+		t.Fatalf("got run id %s, want %s", got.ID, runID)
+	}
+	if got.SpecID != specID {
+		t.Fatalf("got spec id %s, want %s", got.SpecID, specID)
+	}
+	if got.IdempotencyKey == nil || *got.IdempotencyKey != idempotencyKey {
+		t.Fatalf("got idempotency key %v, want %s", got.IdempotencyKey, idempotencyKey)
+	}
+	if got.Lifecycle.Status != run.Failed {
+		t.Fatalf("got status %s, want %s", got.Lifecycle.Status, run.Failed)
+	}
+	if got.Lifecycle.FailureReason == nil || string(*got.Lifecycle.FailureReason) != failureReason {
+		t.Fatalf("got failure reason %v, want %s", got.Lifecycle.FailureReason, failureReason)
+	}
+	if got.Lifecycle.StartedAt == nil {
+		t.Fatal("got nil started_at")
+	}
+	if got.Lifecycle.FinishedAt == nil {
+		t.Fatal("got nil finished_at")
+	}
+}
+
+func TestRunToRunReturnsErrorForInvalidRunID(t *testing.T) {
+	row := Run{
+		ID:        "not-a-uuid",
+		SpecID:    uuid.New().String(),
+		Status:    string(run.Queued),
+		CreatedAt: "2026-05-21T00:00:00Z",
+	}
+
+	if _, err := row.ToRun(); err == nil {
+		t.Fatal("got nil error, want invalid run ID error")
+	}
+}
+
+func TestRunToRunReturnsErrorForInvalidTimestamp(t *testing.T) {
+	row := Run{
+		ID:        uuid.New().String(),
+		SpecID:    uuid.New().String(),
+		Status:    string(run.Queued),
+		CreatedAt: "not-a-time",
+	}
+
+	if _, err := row.ToRun(); err == nil {
+		t.Fatal("got nil error, want invalid timestamp error")
+	}
+}

--- a/internal/manager/repository/db/run.go
+++ b/internal/manager/repository/db/run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
 	"github.com/seedspirit/nano-backend.ai/internal/common/data/run/preset"
 	"github.com/seedspirit/nano-backend.ai/internal/common/data/run/spec"
 	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
@@ -66,6 +67,44 @@ func (r *RunRepository) GetSpec(ctx context.Context, runID uuid.UUID) (spec.Spec
 	row.PresetRefs = refs
 
 	return row.ToSpec()
+}
+
+// ListProjectRuns returns the most recent runs for a project.
+func (r *RunRepository) ListProjectRuns(ctx context.Context, projectID uuid.UUID, limit int) ([]run.Run, error) {
+	var exists int
+	err := r.db.GetContext(ctx, &exists, `
+		SELECT 1
+		FROM projects
+		WHERE id = ?
+	`, projectID.String())
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, errordef.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("check project %s exists: %w", projectID, err)
+	}
+
+	var rows []entity.Run
+	if err := r.db.SelectContext(ctx, &rows, `
+		SELECT id, spec_id, idempotency_key, status, failure_reason,
+			created_at, started_at, finished_at
+		FROM runs
+		WHERE project_id = ?
+		ORDER BY created_at DESC
+		LIMIT ?
+	`, projectID.String(), limit); err != nil {
+		return nil, fmt.Errorf("list runs for project %s: %w", projectID, err)
+	}
+
+	runs := make([]run.Run, 0, len(rows))
+	for i := range rows {
+		item, err := rows[i].ToRun()
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, item)
+	}
+	return runs, nil
 }
 
 func (r *RunRepository) getSpecPresetRefs(ctx context.Context, specID uuid.UUID) (preset.Refs, error) {

--- a/internal/manager/repository/db/run_test.go
+++ b/internal/manager/repository/db/run_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
 	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
 	runspecpreset "github.com/seedspirit/nano-backend.ai/internal/manager/runspec/preset"
 )
@@ -60,43 +61,15 @@ func TestMigrateIsIdempotent(t *testing.T) {
 }
 
 func TestGetSpecUsesRunID(t *testing.T) {
-	ctx := context.Background()
-	repo := newTestRunRepository(t, ctx)
-	projectID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
-	specID := uuid.MustParse("22222222-2222-4222-8222-222222222222")
-	runID := uuid.MustParse("33333333-3333-4333-8333-333333333333")
+	fixture := newRunRepositoryFixture(t)
+	projectID := fixture.givenProject()
+	specID := fixture.givenSpec(projectID, "mergeowl-exp-42")
+	runID := fixture.givenRunForSpec(projectID, specID, testCreatedAt)
 	trainerPresetID := runspecpreset.PresetAxolotlLoRASFT
 
-	if _, err := repo.db.ExecContext(ctx, `
-		INSERT INTO projects (id, name, description, created_at)
-		VALUES (?, ?, ?, ?)
-	`, projectID.String(), "mergeowl", "MergeOwl experiments", testCreatedAt); err != nil {
-		t.Fatalf("insert project: %v", err)
-	}
-	if _, err := repo.db.ExecContext(ctx, `
-		INSERT INTO specs (
-			id, project_id, name, description, model_options, data_options,
-			resource_options, training_options, created_at
-		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, specID.String(), projectID.String(), "mergeowl-exp-42", "LoRA SFT experiment",
-		testModelOptions, testDataOptions, testResourceOptions, testTrainingOptions, testCreatedAt); err != nil {
-		t.Fatalf("insert spec: %v", err)
-	}
-	if _, err := repo.db.ExecContext(ctx, `
-		INSERT INTO spec_preset_refs (spec_id, category, preset_id)
-		VALUES (?, ?, ?)
-	`, specID.String(), "trainer", trainerPresetID.String()); err != nil {
-		t.Fatalf("insert preset ref: %v", err)
-	}
-	if _, err := repo.db.ExecContext(ctx, `
-		INSERT INTO runs (id, project_id, spec_id, status, created_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, runID.String(), projectID.String(), specID.String(), "queued", testCreatedAt); err != nil {
-		t.Fatalf("insert run: %v", err)
-	}
+	fixture.givenTrainerPresetRef(specID, trainerPresetID)
 
-	got, err := repo.GetSpec(ctx, runID)
+	got, err := fixture.repo.GetSpec(fixture.ctx, runID)
 	if err != nil {
 		t.Fatalf("get spec by run id: %v", err)
 	}
@@ -107,9 +80,60 @@ func TestGetSpecUsesRunID(t *testing.T) {
 		t.Fatalf("got trainer preset ref %v, want %s", got.PresetRefs.Trainer, trainerPresetID)
 	}
 
-	_, err = repo.GetSpec(ctx, specID)
+	_, err = fixture.repo.GetSpec(fixture.ctx, specID)
 	if !errors.Is(err, errordef.ErrNotFound) {
 		t.Fatalf("got err %v, want ErrNotFound when using spec id", err)
+	}
+}
+
+func TestListProjectRunsReturnsMostRecentRunsWithinLimit(t *testing.T) {
+	fixture := newRunRepositoryFixture(t)
+	projectID := fixture.givenProject()
+	fixture.givenRun(projectID, "old", "2026-05-21T00:00:00Z")
+	middleRunID := fixture.givenRun(projectID, "middle", "2026-05-21T00:01:00Z")
+	newRunID := fixture.givenRun(projectID, "new", "2026-05-21T00:02:00Z")
+
+	got, err := fixture.repo.ListProjectRuns(fixture.ctx, projectID, 2)
+	if err != nil {
+		t.Fatalf("list project runs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d runs, want 2", len(got))
+	}
+	if got[0].ID != newRunID {
+		t.Fatalf("got first run id %s, want %s", got[0].ID, newRunID)
+	}
+	if got[1].ID != middleRunID {
+		t.Fatalf("got second run id %s, want %s", got[1].ID, middleRunID)
+	}
+	if got[0].Lifecycle.Status != run.Queued {
+		t.Fatalf("got status %s, want %s", got[0].Lifecycle.Status, run.Queued)
+	}
+}
+
+func TestListProjectRunsReturnsEmptyForProjectWithoutRuns(t *testing.T) {
+	fixture := newRunRepositoryFixture(t)
+	projectID := fixture.givenProject()
+
+	got, err := fixture.repo.ListProjectRuns(fixture.ctx, projectID, 20)
+	if err != nil {
+		t.Fatalf("list project runs: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil runs, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d runs, want 0", len(got))
+	}
+}
+
+func TestListProjectRunsReturnsNotFoundForMissingProject(t *testing.T) {
+	fixture := newRunRepositoryFixture(t)
+	projectID := uuid.New()
+
+	_, err := fixture.repo.ListProjectRuns(fixture.ctx, projectID, 20)
+	if !errors.Is(err, errordef.ErrNotFound) {
+		t.Fatalf("got err %v, want ErrNotFound", err)
 	}
 }
 
@@ -127,4 +151,76 @@ func newTestRunRepository(t *testing.T, ctx context.Context) *RunRepository {
 		}
 	})
 	return repo
+}
+
+type runRepositoryFixture struct {
+	t    *testing.T
+	ctx  context.Context
+	repo *RunRepository
+}
+
+func newRunRepositoryFixture(t *testing.T) *runRepositoryFixture {
+	t.Helper()
+	ctx := context.Background()
+	return &runRepositoryFixture{
+		t:    t,
+		ctx:  ctx,
+		repo: newTestRunRepository(t, ctx),
+	}
+}
+
+func (f *runRepositoryFixture) givenProject() uuid.UUID {
+	f.t.Helper()
+	id := uuid.New()
+	if _, err := f.repo.db.ExecContext(f.ctx, `
+		INSERT INTO projects (id, name, description, created_at)
+		VALUES (?, ?, ?, ?)
+	`, id.String(), "mergeowl", "MergeOwl experiments", testCreatedAt); err != nil {
+		f.t.Fatalf("insert project: %v", err)
+	}
+	return id
+}
+
+func (f *runRepositoryFixture) givenSpec(projectID uuid.UUID, name string) uuid.UUID {
+	f.t.Helper()
+	id := uuid.New()
+	if _, err := f.repo.db.ExecContext(f.ctx, `
+		INSERT INTO specs (
+			id, project_id, name, description, model_options, data_options,
+			resource_options, training_options, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), projectID.String(), name, "LoRA SFT experiment",
+		testModelOptions, testDataOptions, testResourceOptions, testTrainingOptions, testCreatedAt); err != nil {
+		f.t.Fatalf("insert spec: %v", err)
+	}
+	return id
+}
+
+func (f *runRepositoryFixture) givenRun(projectID uuid.UUID, name, createdAt string) uuid.UUID {
+	f.t.Helper()
+	specID := f.givenSpec(projectID, name)
+	return f.givenRunForSpec(projectID, specID, createdAt)
+}
+
+func (f *runRepositoryFixture) givenRunForSpec(projectID, specID uuid.UUID, createdAt string) uuid.UUID {
+	f.t.Helper()
+	id := uuid.New()
+	if _, err := f.repo.db.ExecContext(f.ctx, `
+		INSERT INTO runs (id, project_id, spec_id, status, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, id.String(), projectID.String(), specID.String(), "queued", createdAt); err != nil {
+		f.t.Fatalf("insert run: %v", err)
+	}
+	return id
+}
+
+func (f *runRepositoryFixture) givenTrainerPresetRef(specID, presetID uuid.UUID) {
+	f.t.Helper()
+	if _, err := f.repo.db.ExecContext(f.ctx, `
+		INSERT INTO spec_preset_refs (spec_id, category, preset_id)
+		VALUES (?, ?, ?)
+	`, specID.String(), "trainer", presetID.String()); err != nil {
+		f.t.Fatalf("insert preset ref: %v", err)
+	}
 }

--- a/internal/manager/repository/run.go
+++ b/internal/manager/repository/run.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
 	"github.com/seedspirit/nano-backend.ai/internal/common/data/run/spec"
 )
 
 // RunRepository exposes run data needed by manager services.
 type RunRepository interface {
 	GetSpec(ctx context.Context, id uuid.UUID) (spec.Spec, error)
+	ListProjectRuns(ctx context.Context, projectID uuid.UUID, limit int) ([]run.Run, error)
 	Close() error
 }

--- a/internal/manager/servers/v1serv/projectserv/handler.go
+++ b/internal/manager/servers/v1serv/projectserv/handler.go
@@ -1,0 +1,51 @@
+package projectserv
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
+	"github.com/seedspirit/nano-backend.ai/internal/common/dto/response"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
+)
+
+// defaultProjectRunsLimit is the Phase 0 list size before cursor pagination.
+const defaultProjectRunsLimit = 20
+
+type projectHandler struct {
+	svc runService
+}
+
+type runService interface {
+	ListProjectRuns(ctx context.Context, projectID uuid.UUID, limit int) ([]run.Run, error)
+}
+
+func newProjectHandler(args Args) (*projectHandler, error) {
+	if args.Services == nil || args.Services.RunSvc == nil {
+		return nil, errordef.Errorf(errordef.InvalidInput, "run service is required")
+	}
+	return &projectHandler{svc: args.Services.RunSvc}, nil
+}
+
+func (h *projectHandler) listRuns(c *echo.Context) error {
+	ctx := c.Request().Context()
+	projectID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		status, payload := errordef.Response(errordef.ErrInvalidInput, "check the project ID and retry", nil)
+		return c.JSON(status, payload)
+	}
+
+	runs, err := h.svc.ListProjectRuns(ctx, projectID, defaultProjectRunsLimit)
+	if err != nil {
+		status, payload := errordef.Response(err, "retry later or contact an operator", nil)
+		return c.JSON(status, payload)
+	}
+
+	data := response.ProjectRunsData{
+		Runs:  response.NewRunSummaries(projectID, runs),
+		Limit: defaultProjectRunsLimit,
+	}
+	return c.JSON(http.StatusOK, response.OK(data))
+}

--- a/internal/manager/servers/v1serv/projectserv/handler_test.go
+++ b/internal/manager/servers/v1serv/projectserv/handler_test.go
@@ -1,0 +1,166 @@
+package projectserv
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
+	"github.com/seedspirit/nano-backend.ai/internal/common/dto/response"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
+)
+
+func TestNewProjectHandlerRequiresRunService(t *testing.T) {
+	_, err := newProjectHandler(Args{})
+	if err == nil {
+		t.Fatal("got nil error, want dependency error")
+	}
+}
+
+func TestListRunsReturnsEnvelope(t *testing.T) {
+	fixture := newProjectHandlerFixture(t)
+	runID := fixture.givenRun()
+
+	rec := fixture.listRuns(fixture.projectID.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	var body struct {
+		Data response.ProjectRunsData `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Data.Limit != defaultProjectRunsLimit {
+		t.Fatalf("got limit %d, want %d", body.Data.Limit, defaultProjectRunsLimit)
+	}
+	if len(body.Data.Runs) != 1 {
+		t.Fatalf("got %d runs, want 1", len(body.Data.Runs))
+	}
+	if body.Data.Runs[0].ID != runID {
+		t.Fatalf("got run id %s, want %s", body.Data.Runs[0].ID, runID)
+	}
+	if body.Data.Runs[0].ProjectID != fixture.projectID {
+		t.Fatalf("got project id %s, want %s", body.Data.Runs[0].ProjectID, fixture.projectID)
+	}
+}
+
+func TestListRunsReturnsEmptyProjectEnvelope(t *testing.T) {
+	fixture := newProjectHandlerFixture(t)
+
+	rec := fixture.listRuns(fixture.projectID.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusOK)
+	}
+	var body struct {
+		Data response.ProjectRunsData `json:"data"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Data.Runs == nil {
+		t.Fatal("got nil runs, want empty array")
+	}
+	if len(body.Data.Runs) != 0 {
+		t.Fatalf("got %d runs, want 0", len(body.Data.Runs))
+	}
+}
+
+func TestListRunsReturnsInvalidProjectIDEnvelope(t *testing.T) {
+	fixture := newProjectHandlerFixture(t)
+
+	rec := fixture.listRuns("not-a-uuid")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	var body response.Response
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Error == nil || body.Error.Code != "invalid_input" {
+		t.Fatalf("got error payload %#v, want code invalid_input", body.Error)
+	}
+}
+
+func TestListRunsMapsNotFound(t *testing.T) {
+	fixture := newProjectHandlerFixture(t)
+	fixture.givenServiceError(errordef.ErrNotFound)
+
+	rec := fixture.listRuns(fixture.projectID.String())
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+type projectHandlerFixture struct {
+	t         *testing.T
+	projectID uuid.UUID
+	svc       *stubRunService
+	handler   *projectHandler
+}
+
+func newProjectHandlerFixture(t *testing.T) *projectHandlerFixture {
+	t.Helper()
+	svc := &stubRunService{}
+	return &projectHandlerFixture{
+		t:         t,
+		projectID: uuid.New(),
+		svc:       svc,
+		handler:   &projectHandler{svc: svc},
+	}
+}
+
+func (f *projectHandlerFixture) givenRun() uuid.UUID {
+	f.t.Helper()
+	runID := uuid.New()
+	f.svc.runs = append(f.svc.runs, run.Run{
+		ID:     runID,
+		SpecID: uuid.New(),
+		Lifecycle: run.Lifecycle{
+			Status:    run.Queued,
+			CreatedAt: time.Date(2026, 5, 21, 0, 0, 0, 0, time.UTC),
+		},
+	})
+	return runID
+}
+
+func (f *projectHandlerFixture) givenServiceError(err error) {
+	f.t.Helper()
+	f.svc.err = err
+}
+
+func (f *projectHandlerFixture) listRuns(id string) *httptest.ResponseRecorder {
+	f.t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/projects/"+id+"/runs", http.NoBody)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: id}})
+
+	if err := f.handler.listRuns(c); err != nil {
+		f.t.Fatalf("list runs: %v", err)
+	}
+	return rec
+}
+
+type stubRunService struct {
+	runs []run.Run
+	err  error
+}
+
+func (s *stubRunService) ListProjectRuns(_ context.Context, _ uuid.UUID, _ int) ([]run.Run, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.runs == nil {
+		return []run.Run{}, nil
+	}
+	return s.runs, nil
+}

--- a/internal/manager/servers/v1serv/projectserv/server.go
+++ b/internal/manager/servers/v1serv/projectserv/server.go
@@ -1,22 +1,22 @@
-package runserv
+package projectserv
 
 import (
 	"github.com/labstack/echo/v5"
 	"github.com/seedspirit/nano-backend.ai/internal/manager/service"
 )
 
-// Args configures the run API routes.
+// Args configures the project API routes.
 type Args struct {
 	Services *service.Services
 }
 
-// WithSubServer registers run API routes below the given group.
+// WithSubServer registers project API routes below the given group.
 func WithSubServer(g *echo.Group, args Args) error {
-	handler, err := newRunHandler(args)
+	handler, err := newProjectHandler(args)
 	if err != nil {
 		return err
 	}
-	runGroup := g.Group("/runs")
-	runGroup.GET("/:id/spec", handler.getSpec)
+	projectGroup := g.Group("/projects")
+	projectGroup.GET("/:id/runs", handler.listRuns)
 	return nil
 }

--- a/internal/manager/servers/v1serv/runserv/handler.go
+++ b/internal/manager/servers/v1serv/runserv/handler.go
@@ -9,12 +9,7 @@ import (
 	"github.com/seedspirit/nano-backend.ai/internal/common/data/run/spec"
 	"github.com/seedspirit/nano-backend.ai/internal/common/dto/response"
 	"github.com/seedspirit/nano-backend.ai/internal/manager/errordef"
-	"github.com/seedspirit/nano-backend.ai/internal/manager/service"
 )
-
-type handlerArgs struct {
-	Services *service.Services
-}
 
 type runHandler struct {
 	svc runService
@@ -24,7 +19,7 @@ type runService interface {
 	GetSpec(ctx context.Context, runID uuid.UUID) (spec.Spec, error)
 }
 
-func newRunHandler(args handlerArgs) (*runHandler, error) {
+func newRunHandler(args Args) (*runHandler, error) {
 	if args.Services == nil || args.Services.RunSvc == nil {
 		return nil, errordef.Errorf(errordef.InvalidInput, "run service is required")
 	}

--- a/internal/manager/servers/v1serv/runserv/handler_test.go
+++ b/internal/manager/servers/v1serv/runserv/handler_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewRunHandlerRequiresRunService(t *testing.T) {
-	_, err := newRunHandler(handlerArgs{})
+	_, err := newRunHandler(Args{})
 	if err == nil {
 		t.Fatal("got nil error, want dependency error")
 	}
@@ -55,7 +55,16 @@ func TestGetSpecReturnsInvalidRunIDEnvelope(t *testing.T) {
 
 	rec := performGetSpec(t, handler, "not-a-uuid")
 
-	assertErrorEnvelope(t, rec, http.StatusBadRequest, "invalid_run_id")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	var body response.Response
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Error == nil || body.Error.Code != "invalid_run_id" {
+		t.Fatalf("got error payload %#v, want code invalid_run_id", body.Error)
+	}
 }
 
 func TestGetSpecMapsNotFound(t *testing.T) {
@@ -64,7 +73,9 @@ func TestGetSpecMapsNotFound(t *testing.T) {
 
 	rec := performGetSpec(t, handler, runID.String())
 
-	assertErrorEnvelope(t, rec, http.StatusNotFound, "not_found")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("got status %d, want %d", rec.Code, http.StatusNotFound)
+	}
 }
 
 func performGetSpec(t *testing.T, handler *runHandler, id string) *httptest.ResponseRecorder {
@@ -79,26 +90,6 @@ func performGetSpec(t *testing.T, handler *runHandler, id string) *httptest.Resp
 		t.Fatalf("get spec: %v", err)
 	}
 	return rec
-}
-
-func assertErrorEnvelope(t *testing.T, rec *httptest.ResponseRecorder, status int, code string) {
-	t.Helper()
-	if rec.Code != status {
-		t.Fatalf("got status %d, want %d", rec.Code, status)
-	}
-	var body response.Response
-	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if body.Status != status {
-		t.Fatalf("got body status %d, want %d", body.Status, status)
-	}
-	if body.Error == nil {
-		t.Fatal("got nil error payload")
-	}
-	if body.Error.Code != code {
-		t.Fatalf("got error code %q, want %q", body.Error.Code, code)
-	}
 }
 
 type stubRunService struct {

--- a/internal/manager/servers/v1serv/server.go
+++ b/internal/manager/servers/v1serv/server.go
@@ -2,6 +2,7 @@ package v1serv
 
 import (
 	"github.com/labstack/echo/v5"
+	"github.com/seedspirit/nano-backend.ai/internal/manager/servers/v1serv/projectserv"
 	"github.com/seedspirit/nano-backend.ai/internal/manager/servers/v1serv/runserv"
 	"github.com/seedspirit/nano-backend.ai/internal/manager/service"
 )
@@ -15,6 +16,11 @@ type ServerArgs struct {
 func WithSubServer(g *echo.Group, args ServerArgs) error {
 	v1Group := g.Group("/v1")
 	if err := runserv.WithSubServer(v1Group, runserv.Args{
+		Services: args.Services,
+	}); err != nil {
+		return err
+	}
+	if err := projectserv.WithSubServer(v1Group, projectserv.Args{
 		Services: args.Services,
 	}); err != nil {
 		return err

--- a/internal/manager/service/runsvc/run.go
+++ b/internal/manager/service/runsvc/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/seedspirit/nano-backend.ai/internal/common/data/run"
 	"github.com/seedspirit/nano-backend.ai/internal/common/data/run/spec"
 	"github.com/seedspirit/nano-backend.ai/internal/manager/repository"
 )
@@ -16,6 +17,7 @@ type Args struct {
 // RunRepository is the persistence dependency required by the run service.
 type RunRepository interface {
 	GetSpec(ctx context.Context, id uuid.UUID) (spec.Spec, error)
+	ListProjectRuns(ctx context.Context, projectID uuid.UUID, limit int) ([]run.Run, error)
 }
 
 // Service provides run use cases.
@@ -33,4 +35,9 @@ func NewService(args Args) *Service {
 // GetSpec returns the spec associated with a run ID.
 func (s *Service) GetSpec(ctx context.Context, id uuid.UUID) (spec.Spec, error) {
 	return s.repo.GetSpec(ctx, id)
+}
+
+// ListProjectRuns returns the most recent runs associated with a project.
+func (s *Service) ListProjectRuns(ctx context.Context, projectID uuid.UUID, limit int) ([]run.Run, error) {
+	return s.repo.ListProjectRuns(ctx, projectID, limit)
 }


### PR DESCRIPTION
## Issue

Resolves #11

**Problem**: Agents and clients need a project-scoped way to discover recent runs without already knowing individual run IDs. The API also needs to distinguish empty projects from missing projects.

## Solution

**Approach**: Add a project-owned v1 route backed by a run service capability and a SQLite repository query that checks project existence before listing runs newest-first with the Phase 0 default limit.

### Changes
- `internal/manager/servers/v1serv/projectserv` — adds `GET /v1/projects/{id}/runs`, UUID parsing, envelope responses, and handler tests.
- `internal/common/dto/response/run.go` — defines `RunSummary` and `ProjectRunsData` response DTOs.
- `internal/manager/repository/db/run.go` — adds project existence check plus `created_at DESC LIMIT ?` run list query.
- `internal/manager/repository/db/entity/run.go` — maps nullable DB run rows into application `run.Run` data.
- `docs/learn/0016-project-run-list-api/` — records code design, Go, and Backend.AI architecture learnings.

### Key Decisions
| Decision | Why |
|----------|-----|
| New `projectserv` package | The route is project-scoped, so the handler package follows the URL owner. |
| Repository-level existence check | SQLite can distinguish missing project vs. empty project at the persistence boundary. |
| Response DTO instead of `run.Run` directly | The list item is an external API summary contract, not the full domain shape. |

## What I learned
This PR documents project-scoped list route ownership, DTO boundaries, nullable DB row mapping, and Phase 0 list semantics.
See: `docs/learn/0016-project-run-list-api/`

## Test Plan
- [x] `go test ./... -v 2>&1`
- [x] `gofmt -l .`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`